### PR TITLE
Update the Association between Sells and Articles, as well as the current default configuration when users create sales and add articles

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -7,18 +7,18 @@
     @apply shadow rounded border border-gray-200 px-3 py-2 w-full text-sm;
   }
   .btn-without-bg {
-    @apply flex text-sm font-bold rounded px-4 py-2 text-white items-center gap-2
+    @apply flex text-sm font-bold rounded px-4 py-2 text-white items-center gap-2;
   }
   .btn-success {
-    @apply flex text-sm font-bold rounded bg-success px-4 py-2 text-white items-center gap-2
+    @apply flex text-sm font-bold rounded bg-success hover:bg-green-700 px-4 py-2 text-white items-center gap-2 duration-300;
   }
   .btn-danger {
-    @apply flex text-sm font-bold rounded bg-danger px-4 py-2 text-white items-center gap-2;
+    @apply flex text-sm font-bold rounded bg-danger hover:bg-red-700 px-4 py-2 text-white items-center gap-2 duration-300;
   }
   .btn-primary {
-    @apply flex text-sm font-bold rounded bg-primary px-4 py-2 text-white items-center gap-2;
+    @apply flex text-sm font-bold rounded bg-primary hover:bg-cyan-700 px-4 py-2 text-white items-center gap-2 duration-300;
   }
   .btn-warning {
-    @apply flex text-sm font-bold rounded bg-warning px-4 py-2 text-white items-center gap-2;
+    @apply flex text-sm font-bold rounded bg-warning hover:bg-yellow-700 px-4 py-2 text-white items-center gap-2 duration-300;
   }
 }

--- a/app/controllers/article_sells_controller.rb
+++ b/app/controllers/article_sells_controller.rb
@@ -1,0 +1,38 @@
+class ArticleSellsController < ApplicationController
+  before_action :set_sell, only: %i[create destroy]
+  before_action :set_article_sell, only: %i[destroy]
+
+  def create
+    @article_sell = @sell.article_sells.build(article_sell_params)
+
+    respond_to do |format|
+      if @article_sell.save
+        format.turbo_stream { render turbo_stream: turbo_stream.replace('article_sells', partial: 'article_sells/article_sells', locals: { sell: @sell }) }
+      else
+        format.turbo_stream { render turbo_stream: turbo_stream.replace('article_sell_form', partial: 'article_sells/form', locals: { sell: @sell, article_sell: @article_sell, btn_text: 'Añadir articulo' }) }
+      end
+    end
+  end
+
+  def destroy
+    @article_sell.destroy
+
+    respond_to do |format|
+      format.turbo_stream { render turbo_stream: turbo_stream.replace('article_sells', partial: 'article_sells/article_sells', locals: { sell: @sell }) }
+    end
+  end
+
+  private
+
+  def article_sell_params
+    params.require(:article_sell).permit(:article_id, :quantity)
+  end
+
+  def set_sell
+    @sell = Sell.find(params[:sell_id])
+  end
+
+  def set_article_sell
+    @article_sell = ArticleSell.find(params[:id])
+  end
+end

--- a/app/controllers/article_sells_controller.rb
+++ b/app/controllers/article_sells_controller.rb
@@ -1,6 +1,8 @@
 class ArticleSellsController < ApplicationController
-  before_action :set_sell, only: %i[create destroy]
-  before_action :set_article_sell, only: %i[destroy]
+  before_action :set_sell, only: %i[create edit update destroy]
+  before_action :set_article_sell, only: %i[edit update destroy]
+
+  def edit; end
 
   def create
     @article_sell = @sell.article_sells.build(article_sell_params)
@@ -10,6 +12,16 @@ class ArticleSellsController < ApplicationController
         format.turbo_stream { render turbo_stream: turbo_stream.replace('article_sells', partial: 'article_sells/article_sells', locals: { sell: @sell }) }
       else
         format.turbo_stream { render turbo_stream: turbo_stream.replace('article_sell_form', partial: 'article_sells/form', locals: { sell: @sell, article_sell: @article_sell, btn_text: 'Añadir articulo' }) }
+      end
+    end
+  end
+
+  def update
+    respond_to do |format|
+      if @article_sell.update article_sell_params
+        format.turbo_stream { render turbo_stream: turbo_stream.replace('article_sells', partial: 'article_sells/article_sells', locals: { sell: @sell }) }
+      else
+        format.turbo_stream { render turbo_stream: turbo_stream.replace("article_sell_#{@article_sell.id}", partial: 'article_sells/forms/edit', locals: { article_sell: @article_sell }) }
       end
     end
   end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -59,14 +59,10 @@ class ArticlesController < ApplicationController
   def search_by_name
     return unless params[:name].present?
 
-    article = Article.find_by(name: params[:name])
+    articles = Article.search_with_name(params[:name])
 
     respond_to do |format|
-      if article
-        format.turbo_stream { render turbo_stream: turbo_stream.replace('articles', partial: 'articles/articles', locals: { articles: [article], filter_form: FilterForm.new }) }
-      else
-        format.turbo_stream { render turbo_stream: turbo_stream.replace('articles', partial: 'articles/articles', locals: { articles: [], filter_form: FilterForm.new }) }
-      end
+      format.turbo_stream { render turbo_stream: turbo_stream.replace('articles', partial: 'articles/articles', locals: { articles: articles, filter_form: FilterForm.new }) }
     end
   end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -82,7 +82,7 @@ class ArticlesController < ApplicationController
   end
 
   def article_params
-    params.require(:article).permit(:name, :description, :price, :in_stock, :avatar, :promotional_video, images: [])
+    params.require(:article).permit(:name, :description, :price, :avatar, :promotional_video, images: [])
   end
 
   def filter_form_params

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,7 +3,6 @@ class PagesController < ApplicationController
     @revenue = ArticleSell.sum(:revenue).round(2)
     @sells = Sell.all
     @articles = Article.all
-    @article_sells = ArticleSell.all
   end
 
   def settings; end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,8 +1,8 @@
 class PagesController < ApplicationController
   def dashboard
-    @revenue = Sell.sum(:total_revenue).round(2)
-    @sells = Sell.all
-    @articles = Article.all
+    # @revenue = Sell.sum(:total_revenue).round(2)
+    # @sells = Sell.all
+    # @articles = Article.all
   end
 
   def settings; end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,8 +1,9 @@
 class PagesController < ApplicationController
   def dashboard
-    # @revenue = Sell.sum(:total_revenue).round(2)
-    # @sells = Sell.all
-    # @articles = Article.all
+    @revenue = ArticleSell.sum(:revenue).round(2)
+    @sells = Sell.all
+    @articles = Article.all
+    @article_sells = ArticleSell.all
   end
 
   def settings; end

--- a/app/controllers/sells_controller.rb
+++ b/app/controllers/sells_controller.rb
@@ -69,6 +69,6 @@ class SellsController < ApplicationController
   end
 
   def sells_filter_params
-    params.require(:sells_filter).permit(:article_id, :date_min, :date_max, :quantity)
+    params.require(:sells_filter).permit(:date_min, :date_max)
   end
 end

--- a/app/controllers/sells_controller.rb
+++ b/app/controllers/sells_controller.rb
@@ -65,7 +65,7 @@ class SellsController < ApplicationController
   end
 
   def sell_params
-    params.require(:sell).permit(:article_id, :quantity, :date_of_sell, :comment)
+    params.require(:sell).permit(:date_of_sell, :description)
   end
 
   def sells_filter_params

--- a/app/controllers/sells_controller.rb
+++ b/app/controllers/sells_controller.rb
@@ -1,5 +1,5 @@
 class SellsController < ApplicationController
-  before_action :set_sell, only: %i[ show edit update destroy ]
+  before_action :set_sell, only: %i[show edit update destroy]
 
   def index
     @sells = Sell.order(date_of_sell: :desc)
@@ -21,7 +21,7 @@ class SellsController < ApplicationController
       if @sell.save
         format.html { redirect_to sell_url(@sell), notice: 'La venta ha sido creada exitosamente.' }
       else
-        format.html { render :new, status: :unprocessable_entity }
+        format.turbo_stream { render turbo_stream: turbo_stream.replace('new_sell_form', partial: 'sells/form', locals: { sell: @sell, id: 'new_sell_form', btn_text: 'Crear' }) }
       end
     end
   end
@@ -31,7 +31,7 @@ class SellsController < ApplicationController
       if @sell.update(sell_params)
         format.html { redirect_to sell_url(@sell), notice: 'La venta ha sido actualizada exitosamente.' }
       else
-        format.html { render :edit, status: :unprocessable_entity }
+        format.turbo_stream { render turbo_stream: turbo_stream.replace('edit_sell_form', partial: 'sells/form', locals: { sell: @sell, id: 'edit_sell_form', btn_text: 'Actualizar' }) }
       end
     end
   end

--- a/app/forms/sells_filter.rb
+++ b/app/forms/sells_filter.rb
@@ -1,14 +1,10 @@
 class SellsFilter
   include ActiveModel::Model
 
-  attr_accessor :article_id, :date_min, :date_max
+  attr_accessor :date_min, :date_max
 
-  validate :article_exists
   validate :date_min_less_than_date_max
   validate :date_max_equal_today_date
-
-  define_model_callbacks :save
-  before_save :format_dates
 
   def save
     self.date_min = date_min.to_date
@@ -20,20 +16,12 @@ class SellsFilter
   end
 
   def search
-    sells = set_sells
-
-    sells = by_date(sells)
+    sells = by_date(Sell.all)
 
     sells.order(date_of_sell: :desc)
   end
 
   private
-
-  def article_exists
-    return unless article_id.present?
-
-    errors.add(:article_id, :does_not_exist) unless Article.find_by(id: article_id).present?
-  end
 
   def date_min_less_than_date_max
     return unless date_min.present? && date_max.present?
@@ -45,12 +33,6 @@ class SellsFilter
     return unless date_max.present?
 
     errors.add(:date_max, :more_than_today) if date_max.to_date > Date.today
-  end
-
-  def set_sells
-    return Article.find(article_id).sells if article_id.present?
-
-    Sell.all
   end
 
   def by_date(sells)

--- a/app/forms/sells_filter.rb
+++ b/app/forms/sells_filter.rb
@@ -1,9 +1,8 @@
 class SellsFilter
   include ActiveModel::Model
 
-  attr_accessor :article_id, :date_min, :date_max, :quantity
+  attr_accessor :article_id, :date_min, :date_max
 
-  validate :quantity_positive_numbers
   validate :article_exists
   validate :date_min_less_than_date_max
   validate :date_max_equal_today_date
@@ -25,18 +24,10 @@ class SellsFilter
 
     sells = by_date(sells)
 
-    sells = by_quantity(sells) if quantity.present?
-
     sells.order(date_of_sell: :desc)
   end
 
   private
-
-  def quantity_positive_numbers
-    return unless quantity.present?
-
-    errors.add(:quantity, :positive_numbers) if quantity.to_i.negative?
-  end
 
   def article_exists
     return unless article_id.present?
@@ -67,9 +58,5 @@ class SellsFilter
     sells = Sell.filter_with_date_max(sells, date_max.to_date) if date_max.present?
 
     sells
-  end
-
-  def by_quantity(sells)
-    sells.where(quantity: quantity)
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,12 +1,10 @@
 class Article < ApplicationRecord
-  scope :available_in_stock, -> { where('in_stock > 0') }
   scope :with_min_price, ->(articles, min_price) { articles.where('price > ?', min_price) }
   scope :with_max_price, ->(articles, max_price) { articles.where('price < ?', max_price) }
 
-  validates :name, :description, :price, :in_stock, presence: true
+  validates :name, :price, presence: true
   validates :name, uniqueness: true
   validates :price, comparison: { greater_than_or_equal_to: 0 }
-  validates :in_stock, comparison: { greater_than_or_equal_to: 0 }
   validates :avatar, content_type: ['image/png', 'image/jpg', 'image/jpeg', 'image/gif']
   validates :promotional_video, content_type: ['video/mp4', 'video/webm']
 
@@ -19,8 +17,4 @@ class Article < ApplicationRecord
 
   has_many :article_sells
   has_many :sells, through: :article_sells
-
-  def name_with_in_stock
-    "#{name} (#{in_stock} pz disp)"
-  end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -15,8 +15,10 @@ class Article < ApplicationRecord
   has_many_attached :images
 
   has_rich_text :description
-  has_many :sells, dependent: :destroy
   has_and_belongs_to_many :categories
+
+  has_many :article_sells
+  has_many :sells, through: :article_sells
 
   def name_with_in_stock
     "#{name} (#{in_stock} pz disp)"

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,5 @@
 class Article < ApplicationRecord
+  scope :search_with_name, ->(name) { where("name LIKE '%#{name}%'") }
   scope :with_min_price, ->(articles, min_price) { articles.where('price > ?', min_price) }
   scope :with_max_price, ->(articles, max_price) { articles.where('price < ?', max_price) }
 
@@ -13,8 +14,8 @@ class Article < ApplicationRecord
   has_many_attached :images
 
   has_rich_text :description
-  has_and_belongs_to_many :categories
 
   has_many :article_sells
   has_many :sells, through: :article_sells
+  has_and_belongs_to_many :categories
 end

--- a/app/models/article_sell.rb
+++ b/app/models/article_sell.rb
@@ -1,0 +1,29 @@
+class ArticleSell < ApplicationRecord
+  belongs_to :article
+  belongs_to :sell
+
+  validates :quantity, presence: true
+
+  # validate :availability_in_stock, on: :create
+
+  # after_create :decrease_in_stock_article
+  # before_save :set_total_revenue
+
+  private
+
+  # def availability_in_stock
+  #   return unless article && quantity
+
+  #   errors.add(:quantity, :insufficient_articles) if quantity > article.in_stock
+  # end
+
+  # def decrease_in_stock_article
+  #   current_stock = article.in_stock
+
+  #   article.update!(in_stock: current_stock - quantity)
+  # end
+
+  # def set_total_revenue
+  #   self.total_revenue = quantity.to_d * article.price.to_d
+  # end
+end

--- a/app/models/article_sell.rb
+++ b/app/models/article_sell.rb
@@ -1,6 +1,4 @@
 class ArticleSell < ApplicationRecord
-  scope :calculate_articles_quantity, ->(id) { where(article_id: id).sum(:quantity) }
-
   belongs_to :article
   belongs_to :sell
 

--- a/app/models/article_sell.rb
+++ b/app/models/article_sell.rb
@@ -1,31 +1,19 @@
 class ArticleSell < ApplicationRecord
+  scope :calculate_articles_quantity, ->(id) { where(article_id: id).sum(:quantity) }
+
   belongs_to :article
   belongs_to :sell
 
   validates :article_id, :quantity, presence: true
   validates :quantity, comparison: { greater_than_or_equal_to: 0 }
   validate :article_exists?
-  validate :availability_in_stock, on: :create
 
-  after_create :decrease_in_stock_article
   before_save :set_revenue
 
   private
 
   def article_exists?
     errors.add(:article_id, :article_does_not_exist) unless Article.find_by(id: article_id).present?
-  end
-
-  def availability_in_stock
-    return unless Article.find_by(id: article_id).present?
-
-    errors.add(:quantity, :insufficient_articles) if quantity > Article.find_by(id: article_id).in_stock
-  end
-
-  def decrease_in_stock_article
-    current_stock = article.in_stock
-
-    article.update!(in_stock: current_stock - quantity)
   end
 
   def set_revenue

--- a/app/models/sell.rb
+++ b/app/models/sell.rb
@@ -10,21 +10,21 @@ class Sell < ApplicationRecord
 
   before_destroy :delete_articles_associations
 
-  def self.latest_sells
+  def self.revenue_by_day
     data = []
-    thirty_days_from_today = [Date.today]
 
-    Array.new(30).each_with_index do |_, i|
-      thirty_days_from_today << Date.today - i.day
-    end
+    for i in 0...30
+      day_total_revenue = 0
+      from_date = Date.today - i.day
 
-    thirty_days_from_today.each do |day|
-      sells = Sell.where(date_of_sell: day)
-      total_revenue = 0
+      sells = Sell.where(date_of_sell: from_date)
 
-      sells.each { |sell| total_revenue += sell.article_sells.sum(:revenue) }
+      sells.each do |sell|
+        sell_revenue = sell.article_sells.sum(:revenue)
+        day_total_revenue += sell_revenue
+      end
 
-      data << [day, total_revenue]
+      data << [from_date, day_total_revenue]
     end
 
     data

--- a/app/models/sell.rb
+++ b/app/models/sell.rb
@@ -2,46 +2,25 @@ class Sell < ApplicationRecord
   scope :filter_with_date_min, ->(sells, date_min) { sells.where('date_of_sell >= ?', date_min) }
   scope :filter_with_date_max, ->(sells, date_max) { sells.where('date_of_sell <= ?', date_max) }
 
-  belongs_to :article, counter_cache: true
+  validates :date_of_sell, presence: true
 
-  validates :quantity, :date_of_sell, :article, presence: true
-  validate :availability_in_stock, on: :create
-
-  after_create :decrease_in_stock_article
-  before_save :set_total_revenue
+  has_many :article_sells
+  has_many :articles, through: :article_sells
 
   def self.latest_sells
-    data = []
-    thirty_days_from_today = [Date.today]
+    # data = []
+    # thirty_days_from_today = [Date.today]
 
-    for i in 1..30
-      prev_day = Date.today - i.day
-      thirty_days_from_today << prev_day
-    end
+    # for i in 1..30
+    #   prev_day = Date.today - i.day
+    #   thirty_days_from_today << prev_day
+    # end
 
-    thirty_days_from_today.each do |day|
-      revenue_day = Sell.where(date_of_sell: day).sum(:total_revenue)
-      data << [day, revenue_day]
-    end
+    # thirty_days_from_today.each do |day|
+    #   revenue_day = Sell.where(date_of_sell: day).sum(:total_revenue)
+    #   data << [day, revenue_day]
+    # end
 
-    data
-  end
-
-  private
-
-  def availability_in_stock
-    return unless article && quantity
-
-    errors.add(:quantity, :insufficient_articles) if quantity > article.in_stock
-  end
-
-  def decrease_in_stock_article
-    current_stock = article.in_stock
-
-    article.update!(in_stock: current_stock - quantity)
-  end
-
-  def set_total_revenue
-    self.total_revenue = quantity.to_d * article.price.to_d
+    [Date.today, 10]
   end
 end

--- a/app/models/sell.rb
+++ b/app/models/sell.rb
@@ -11,20 +11,23 @@ class Sell < ApplicationRecord
   before_destroy :delete_articles_associations
 
   def self.latest_sells
-    # data = []
-    # thirty_days_from_today = [Date.today]
+    data = []
+    thirty_days_from_today = [Date.today]
 
-    # for i in 1..30
-    #   prev_day = Date.today - i.day
-    #   thirty_days_from_today << prev_day
-    # end
+    Array.new(30).each_with_index do |_, i|
+      thirty_days_from_today << Date.today - i.day
+    end
 
-    # thirty_days_from_today.each do |day|
-    #   revenue_day = Sell.where(date_of_sell: day).sum(:total_revenue)
-    #   data << [day, revenue_day]
-    # end
+    thirty_days_from_today.each do |day|
+      sells = Sell.where(date_of_sell: day)
+      total_revenue = 0
 
-    [Date.today, 10]
+      sells.each { |sell| total_revenue += sell.article_sells.sum(:revenue) }
+
+      data << [day, total_revenue]
+    end
+
+    data
   end
 
   private

--- a/app/models/sell.rb
+++ b/app/models/sell.rb
@@ -3,9 +3,12 @@ class Sell < ApplicationRecord
   scope :filter_with_date_max, ->(sells, date_max) { sells.where('date_of_sell <= ?', date_max) }
 
   validates :date_of_sell, presence: true
+  validate :date_of_sell_less_than_today
 
   has_many :article_sells
   has_many :articles, through: :article_sells
+
+  before_destroy :delete_articles_associations
 
   def self.latest_sells
     # data = []
@@ -22,5 +25,17 @@ class Sell < ApplicationRecord
     # end
 
     [Date.today, 10]
+  end
+
+  private
+
+  def date_of_sell_less_than_today
+    return unless date_of_sell.present?
+
+    errors.add(:date_of_sell, :greater_than_today) if date_of_sell.to_date > Date.today
+  end
+
+  def delete_articles_associations
+    ArticleSell.where(sell_id: id).delete_all
   end
 end

--- a/app/views/article_sells/_article_sell.html.erb
+++ b/app/views/article_sells/_article_sell.html.erb
@@ -1,0 +1,22 @@
+<div class="flex items-center w-full border-b py-2">
+  <div class="w-1/12 text-sidebarTextColor font-semibold text-sm"><%= article_sell.article.id %></div>
+  <div class="w-1/12 text-sidebarTextColor font-semibold text-sm">
+    <% if article_sell.article.avatar.attached? %>
+      <%= image_tag(article_sell.article.avatar, class: 'w-10 h-10 rounded-full shadow shadow-slate-400 border object-contain') %>
+    <% else %>
+      <div class="w-10 h-10 shadow shadow-slate-400 rounded-full border bg-gradient-to-br from-cyan-300 to-green-300"></div>
+    <% end %>
+  </div>
+  <div class="w-4/12 text-sidebarTextColor font-semibold text-sm"><%= article_sell.article.name %></div>
+  <div class="w-1/12 text-sidebarTextColor font-semibold text-sm text-center"><%= article_sell.quantity %></div>
+  <div class="w-2/12 text-sidebarTextColor font-semibold text-sm text-end">$ <%= number_with_delimiter(article_sell.article.price.round(2), :delimiter => ',') %> MXN</div>
+  <div class="w-2/12 text-sidebarTextColor font-semibold text-sm text-end">$ <%= number_with_delimiter(article_sell.revenue.round(2), :delimiter => ',') %> MXN</div>
+  <div class="w-1/12 flex items-center justify-end gap-5">
+    <%= link_to sell_article_sell_path(article_sell, sell_id: article_sell.sell.id), class: 'font-semibold gap-2 flex items-center text-primary hover:text-cyan-800 duration-300' do %>
+      <i class="fa-solid fa-pen-to-square"></i>
+    <% end %>
+    <%= button_to sell_article_sell_path(article_sell, sell_id: article_sell.sell.id), method: :delete, form: { data: { turbo_confirm: 'Estas seguro de eliminar este articulo?' } }, class: 'text-lg font-semibold gap-2 flex items-center text-danger hover:text-red-800 duration-300' do %>
+      <i class="fa-solid fa-trash"></i>
+    <% end %>
+  </div>
+</div>

--- a/app/views/article_sells/_article_sell.html.erb
+++ b/app/views/article_sells/_article_sell.html.erb
@@ -1,4 +1,4 @@
-<div class="flex items-center w-full border-b py-2">
+<%= turbo_frame_tag "article_sell_#{article_sell.id}", class: 'flex items-center w-full border-b py-2' do %>
   <div class="w-1/12 text-sidebarTextColor font-semibold text-sm"><%= article_sell.article.id %></div>
   <div class="w-1/12 text-sidebarTextColor font-semibold text-sm">
     <% if article_sell.article.avatar.attached? %>
@@ -12,11 +12,11 @@
   <div class="w-2/12 text-sidebarTextColor font-semibold text-sm text-end">$ <%= number_with_delimiter(article_sell.article.price.round(2), :delimiter => ',') %> MXN</div>
   <div class="w-2/12 text-sidebarTextColor font-semibold text-sm text-end">$ <%= number_with_delimiter(article_sell.revenue.round(2), :delimiter => ',') %> MXN</div>
   <div class="w-1/12 flex items-center justify-end gap-5">
-    <%= link_to sell_article_sell_path(article_sell, sell_id: article_sell.sell.id), class: 'font-semibold gap-2 flex items-center text-primary hover:text-cyan-800 duration-300' do %>
+    <%= link_to edit_sell_article_sell_path(article_sell, sell_id: article_sell.sell.id), class: 'font-semibold gap-2 flex items-center text-primary hover:text-cyan-800 duration-300' do %>
       <i class="fa-solid fa-pen-to-square"></i>
     <% end %>
     <%= button_to sell_article_sell_path(article_sell, sell_id: article_sell.sell.id), method: :delete, form: { data: { turbo_confirm: 'Estas seguro de eliminar este articulo?' } }, class: 'text-lg font-semibold gap-2 flex items-center text-danger hover:text-red-800 duration-300' do %>
       <i class="fa-solid fa-trash"></i>
     <% end %>
   </div>
-</div>
+<% end %>

--- a/app/views/article_sells/_article_sells.html.erb
+++ b/app/views/article_sells/_article_sells.html.erb
@@ -1,0 +1,28 @@
+<div class="flex flex-col w-full gap-5" id="article_sells">
+  <div class="flex flex-col w-full bg-white p-5 shadow rounded border">
+    <%= render 'article_sells/form', { sell: sell, article_sell: ArticleSell.new, btn_text: 'Añadir articulo' } %>
+  </div>
+
+  <div class="flex flex-col w-full gap-5 bg-white p-5 shadow rounded border">
+    <div class="flex w-full items-center justify-between">
+      <h5 class="font-bold text-lg text-sidebarTextColor">Articulos añadidos</h5>
+      <p class="font-medium text-sidebarTextColor">Total: <span class="font-bold underline">$ <%= number_with_delimiter(sell.article_sells.sum(:revenue).round(2), :delimiter => ',') %> MXN</span></p>
+    </div>
+    <div class="flex flex-col gap-2">
+      <div class="flex w-full bg-gray-100 rounded px-5">
+        <div class="w-1/12 text-sidebarTextColor font-bold">ID</div>
+        <div class="w-1/12 text-sidebarTextColor font-bold">Imagen</div>
+        <div class="w-4/12 text-sidebarTextColor font-bold">Articulo</div>
+        <div class="w-1/12 text-sidebarTextColor font-bold text-center">Cantidad</div>
+        <div class="w-2/12 text-sidebarTextColor font-bold text-end">Precio</div>
+        <div class="w-2/12 text-sidebarTextColor font-bold text-end">Ganancias</div>
+        <div class="w-1/12 text-sidebarTextColor font-bold text-end">Opciones</div>
+      </div>
+      <div class="flex flex-col w-full gap-2 px-5">
+        <% sell.article_sells.each do |article_sell| %>
+          <%= render 'article_sells/article_sell', { article_sell: article_sell } %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/article_sells/_article_sells.html.erb
+++ b/app/views/article_sells/_article_sells.html.erb
@@ -19,7 +19,7 @@
         <div class="w-1/12 text-sidebarTextColor font-bold text-end">Opciones</div>
       </div>
       <div class="flex flex-col w-full gap-2 px-5">
-        <% sell.article_sells.each do |article_sell| %>
+        <% sell.article_sells.order(created_at: :asc).each do |article_sell| %>
           <%= render 'article_sells/article_sell', { article_sell: article_sell } %>
         <% end %>
       </div>

--- a/app/views/article_sells/_form.html.erb
+++ b/app/views/article_sells/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with(model: article_sell, url: sell_article_sells_path(sell), method: :post, class: 'flex flex-col w-full', id: 'article_sell_form') do |f| %>
+  <div class="flex items-start justify-between">
+    <h5 class="font-bold text-lg text-sidebarTextColor">Añadir articulo</h5>
+    <div class="flex items-center justify-end gap-3">
+      <%= f.submit 'Añadir articulo', class: "rounded py-2 px-4 bg-green-500 text-white font-semibold cursor-pointer", data: { turbo_frame: '_top' } %>
+    </div>
+  </div>
+
+
+  <div class="flex items-start w-full gap-5">
+    <div class="flex flex-col gap-1 items-start w-6/12">
+      <%= f.label :article_id, 'Seleccionar articulo:', class: 'font-bold mb-1' %>
+      <%= f.select(:article_id, Article.available_in_stock.order(:name).map { |option| [option.name_with_in_stock, option.id] },
+        { include_blank: true },
+        { class: "input-tailwindcss font-semibold #{ error_input_border(article_sell.errors.include?(:article_id)) }"
+      }) %>
+      <% if article_sell.errors.include?(:article_id) %>
+        <%= render 'shared/input_error_msg', { object: article_sell, attribute: :article_id } %>
+      <% end %>
+    </div>
+
+    <div class="flex flex-col gap-1 items-start w-6/12">
+      <%= f.label :quantity, 'Cantidad de piezas:', class: 'font-bold mb-1' %>
+      <%= f.text_field :quantity, class: "input-tailwindcss font-semibold #{ error_input_border(article_sell.errors.include?(:quantity)) }" %>
+      <% if article_sell.errors.include?(:quantity) %>
+        <%= render 'shared/input_error_msg', { object: article_sell, attribute: :quantity } %>
+      <% end %>
+    </div>
+  </div>
+
+
+<% end %>

--- a/app/views/article_sells/_form.html.erb
+++ b/app/views/article_sells/_form.html.erb
@@ -6,7 +6,6 @@
     </div>
   </div>
 
-
   <div class="flex items-start w-full gap-5">
     <div class="flex flex-col gap-1 items-start w-6/12">
       <%= f.label :article_id, 'Seleccionar articulo:', class: 'font-bold mb-1' %>
@@ -27,6 +26,4 @@
       <% end %>
     </div>
   </div>
-
-
 <% end %>

--- a/app/views/article_sells/_form.html.erb
+++ b/app/views/article_sells/_form.html.erb
@@ -9,7 +9,7 @@
   <div class="flex items-start w-full gap-5">
     <div class="flex flex-col gap-1 items-start w-6/12">
       <%= f.label :article_id, 'Seleccionar articulo:', class: 'font-bold mb-1' %>
-      <%= f.select(:article_id, Article.available_in_stock.order(:name).map { |option| [option.name_with_in_stock, option.id] },
+      <%= f.select(:article_id, Article.all.order(:name).map { |option| [option.name, option.id] },
         { include_blank: true },
         { class: "input-tailwindcss font-semibold #{ error_input_border(article_sell.errors.include?(:article_id)) }"
       }) %>

--- a/app/views/article_sells/edit.html.erb
+++ b/app/views/article_sells/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render 'article_sells/forms/edit', { article_sell: @article_sell } %>

--- a/app/views/article_sells/forms/_edit.html.erb
+++ b/app/views/article_sells/forms/_edit.html.erb
@@ -1,0 +1,31 @@
+<%= turbo_frame_tag "article_sell_#{article_sell.id}", class: 'flex w-full' do %>
+  <%= form_with(model: article_sell, url: sell_article_sell_path(@article_sell.sell), class: 'flex flex-col w-full gap-3 my-5 border shadow rounded p-2') do |f| %>
+    <h5 class="font-bold text-lg text-sidebarTextColor">Editar articulo</h5>
+
+    <div class="flex items-start w-full gap-5">
+      <div class="flex flex-col gap-1 items-start w-6/12">
+        <%= f.label :article_id, 'Seleccionar articulo:', class: 'font-bold mb-1' %>
+        <%= f.select(:article_id, Article.all.order(:name).map { |option| [option.name_with_in_stock, option.id] },
+          { include_blank: true },
+          { class: "input-tailwindcss font-semibold #{ error_input_border(article_sell.errors.include?(:article_id)) }"
+        }) %>
+        <% if article_sell.errors.include?(:article_id) %>
+          <%= render 'shared/input_error_msg', { object: article_sell, attribute: :article_id } %>
+        <% end %>
+      </div>
+
+      <div class="flex flex-col gap-1 items-start w-6/12">
+        <%= f.label :quantity, 'Cantidad de piezas:', class: 'font-bold mb-1' %>
+        <%= f.text_field :quantity, class: "input-tailwindcss font-semibold #{ error_input_border(article_sell.errors.include?(:quantity)) }" %>
+        <% if article_sell.errors.include?(:quantity) %>
+          <%= render 'shared/input_error_msg', { object: article_sell, attribute: :quantity } %>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="flex items-center justify-end gap-3">
+      <%= f.submit 'Actualizar', class: "rounded py-2 px-4 bg-green-500 text-white font-semibold cursor-pointer", data: { turbo_frame: '_top' } %>
+      <%= link_to 'Cancelar', :back, class: 'btn-danger' %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/article_sells/forms/_edit.html.erb
+++ b/app/views/article_sells/forms/_edit.html.erb
@@ -5,7 +5,7 @@
     <div class="flex items-start w-full gap-5">
       <div class="flex flex-col gap-1 items-start w-6/12">
         <%= f.label :article_id, 'Seleccionar articulo:', class: 'font-bold mb-1' %>
-        <%= f.select(:article_id, Article.all.order(:name).map { |option| [option.name_with_in_stock, option.id] },
+        <%= f.select(:article_id, Article.all.order(:name).map { |option| [option.name, option.id] },
           { include_blank: true },
           { class: "input-tailwindcss font-semibold #{ error_input_border(article_sell.errors.include?(:article_id)) }"
         }) %>

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -1,82 +1,78 @@
 <%= turbo_frame_tag 'add_categories_modal' %>
 
-<div class="flex flex-col gap-5 rounded shadow border p-5 bg-white">
+<div class="flex flex-col gap-10 rounded shadow border p-5 bg-white">
   <div class="flex items-center justify-between w-full">
     <%= render 'shared/breadcumb', { path: articles_path, path_text: 'Articulos', text: article.name } %>
 
-    <%= link_to add_categories_article_path(article), class: 'btn-warning', data: { turbo_frame: 'add_categories_modal' } do %>
-      Asignar categorias
-    <% end %>
+    <div class="flex items-center gap-2">
+      <%= link_to add_categories_article_path(article), class: 'btn-warning', data: { turbo_frame: 'add_categories_modal' } do %>
+        Asignar categorias
+      <% end %>
+      <%= link_to edit_article_path(@article), class: "btn-primary" do %>
+        <i class="fa-solid fa-pen-to-square"></i> Editar
+      <% end %>
+      <%= button_to article_path(article), method: :delete, form: { data: { turbo_confirm: 'Estas seguro de eliminar este articulo?' } }, class: "btn-danger" do %>
+        <i class="fa-solid fa-trash"></i> Eliminar
+      <% end %>
+    </div>
   </div>
 
-  <div class="flex flex-col gap-10 w-full">
-    <div class="flex flex-col items-center gap-10 w-full">
+  <div class="flex items-center w-full gap-2">
+    <div class="flex flex-col w-full gap-5">
+      <div class="flex gap-2 text-sidebarTextColor">
+        Nombre:
+        <span class="font-semibold"><%= article.name %></span>
+      </div>
+      <div class="flex gap-2 text-sidebarTextColor">
+        Precio:
+        <span class="font-semibold">$ <%= number_with_delimiter(article.price.round(2), :delimiter => ',') %> MXN</span>
+      </div>
+      <div class="flex gap-2 text-sidebarTextColor">
+        <span>Categorias:</span>
+        <div class="flex items-center gap-2">
+          <% if article.categories.any? %>
+            <% article.categories.each do |category| %>
+              <span class="text-xs text-white py-1 px-3 rounded bg-yellow-600"><%= category.name %></span>
+            <% end %>
+          <% else %>
+            Este articulo aún no cuenta con ninguna categoría asignada.
+          <% end %>
+        </div>
+      </div>
+      <div class="flex flex-col text-sidebarTextColor gap-2">
+        <span>Descripción:</span>
+        <span class="font-semibold text-sm">
+          <%= article.description.present? ? article.description : 'Sin descripción' %>
+        </span>
+      </div>
+
+      <div class="flex flex-col text-sidebarTextColor gap-2">
+        <span>Más imagenes:</span>
+        <% if article.images.any? %>
+          <div class="flex items-center mt-5 gap-10">
+            <% article.images.each do |image| %>
+              <%= image_tag(image, class: 'border shadow-lg rounded-full w-20 h-20 object-cover hover:scale-110 duration-300 hover:scale-150') %>
+            <% end %>
+          </div>
+        <% else %>
+          <p class="font-semibold">No se han añadido más imagenes</p>
+        <% end %>
+      </div>
+    </div>
+    <div class="flex items-center justify-center w-4/12">
       <% if article.avatar.attached? %>
         <%= image_tag(article.avatar, class: 'w-60 h-60 rounded-full shadow-lg shadow-slate-400 border object-contain') %>
       <% else %>
         <div class="w-60 h-60 shadow shadow-slate-400 rounded-full border bg-gradient-to-br from-cyan-300 to-green-300"></div>
       <% end %>
-
-      <div class="flex flex-col items-center justify-center w-full gap-5">
-        <h3 class="text-2xl font-semibold"><%= article.name %></h3>
-
-        <div class="flex items-center gap-5">
-          <%= link_to edit_article_path(@article), class: "text-xl font-semibold underline gap-2 flex items-center text-primary hover:text-cyan-800 duration-300" do %>
-            <i class="fa-solid fa-pen-to-square"></i>
-          <% end %>
-          <%= button_to article_path(article), method: :delete, form: { data: { turbo_confirm: 'Estas seguro de eliminar este articulo?' } }, class: "text-xl font-semibold underline gap-2 flex items-center text-danger hover:text-red-800 duration-300" do %>
-            <i class="fa-solid fa-trash"></i>
-          <% end %>
-        </div>
-      </div>
     </div>
-
-    <div class="flex items-center justify-center gap-5 w-full">
-      <div class="flex gap-1">
-        <h4 class="font-medium mb-1">Precio:</h4>
-        $ <%= number_with_delimiter(article.price.round(2), :delimiter => ',') %> MXN
-      </div>
-
-      <div class="flex gap-1">
-        <h4 class="font-medium mb-1">Cantidad:</h4>
-        <%= article.in_stock %> piezas
-      </div>
-    </div>
-
-    <% if article.promotional_video.attached? %>
-      <div class="flex flex-col items-center justify-center gap-2">
-        <h4 class="font-medium">Video Promocional</h4>
-        <video src=<%= url_for(article.promotional_video) %> class="w-[600px]" controls></video>
-      </div>
-    <% end %>
-
-    <div class="flex flex-col items-center w-full">
-      <h4 class="font-medium mb-1">Categorias:</h4>
-      <div class="flex gap-2">
-        <% if article.categories.any? %>
-          <% article.categories.each do |category| %>
-            <span class="text-xs text-white py-1 px-3 rounded-xl bg-yellow-600"><%= category.name %></span>
-          <% end %>
-        <% else %>
-          Este articulo aún no cuenta con ninguna categoría asignada.
-        <% end %>
-      </div>
-    </div>
-
-    <div class="flex flex-col items-center gap-1">
-      <h4 class="font-medium mb-1">Descripción:</h4>
-      <span class="text-center"><%= article.description %></span>
-    </div>
-
-    <% if article.images.any? %>
-      <div class="flex flex-col gap-5 w-full">
-        <h4 class="font-medium mb-1 text-center">Mas imagenes:</h4>
-        <div class="flex flex-col items-center gap-10 justify-center">
-          <% article.images.each do |image| %>
-            <%= image_tag(image, class: 'border shadow-lg rounded-full w-60 h-60 object-cover hover:scale-110 duration-300 ') %>
-          <% end %>
-        </div>
-      </div>
-    <% end %>
   </div>
 </div>
+
+<%# if article.promotional_video.attached? %>
+  <%# <div class="flex flex-col items-center justify-center gap-2">
+    <h4 class="font-medium">Video Promocional</h4> %>
+    <%# <video src== url_for(article.promotional_video) class="w-[600px]" controls></video> %>
+  <%# </div> %>
+<%# end %>
+

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -17,7 +17,7 @@
     </div>
   </div>
 
-  <div class="flex items-center w-full gap-2">
+  <div class="flex items-center w-full gap-2 mb-5">
     <div class="flex flex-col w-full gap-5">
       <div class="flex gap-2 text-sidebarTextColor">
         Nombre:

--- a/app/views/articles/_articles.html.erb
+++ b/app/views/articles/_articles.html.erb
@@ -12,24 +12,20 @@
         </div>
 
         <div class="w-1/12 p-1 font-bold text-sidebarTextColor">Imagen</div>
-        <div class="flex items-center w-4/12">
+
+        <div class="flex items-center w-5/12">
           <%= button_to filter_articles_path, params: { attribute: 'name' }, class: 'flex items-center w-full gap-1 p-1 font-bold text-sidebarTextColor' do %>
             <i class="fa-solid fa-arrow-down-short-wide"></i>
             <span>Nombre</span>
           <% end %>
         </div>
-        <div class="w-2/12 p-1 font-bold text-sidebarTextColor">Categorias</div>
+
+        <div class="w-3/12 p-1 font-bold text-sidebarTextColor">Categorias</div>
+
         <div class="flex items-center w-2/12">
           <%= button_to filter_articles_path, params: { attribute: 'price' }, class: 'flex items-center w-full gap-1 p-1 font-bold text-sidebarTextColor' do %>
             <i class="fa-solid fa-arrow-down-short-wide"></i>
             <span>Precio</span>
-          <% end %>
-        </div>
-        <div class="w-1/12 p-1 font-bold text-sidebarTextColor text-center">Activo</div>
-        <div class="flex items-center w-1/12">
-          <%= button_to filter_articles_path, params: { attribute: 'in_stock' }, class: 'flex items-center w-full gap-1 p-1 font-bold text-sidebarTextColor' do %>
-            <i class="fa-solid fa-arrow-down-short-wide"></i>
-            <span>Cantidad</span>
           <% end %>
         </div>
       </div>
@@ -45,21 +41,13 @@
                 <div class="w-10 h-10 shadow shadow-slate-400 rounded-full border bg-gradient-to-br from-cyan-300 to-green-300"></div>
               <% end %>
             </div>
-            <div class="font-semibold text-sm text-sidebarTextColor p-1 w-4/12"><%= article.name %></div>
-            <div class="font-semibold text-sm text-sidebarTextColor p-1 w-2/12 gap-1 grid">
+            <div class="font-semibold text-sm text-sidebarTextColor p-1 w-5/12"><%= article.name %></div>
+            <div class="font-semibold text-sm text-sidebarTextColor p-1 w-3/12 gap-1 grid">
               <% article.categories.order(:created_at).each do |category| %>
                 <span class="text-xs border border-gray-700 px-1.5 py-0.5 rounded ml-0 mr-auto"><%= category.name %></span>
               <% end %>
             </div>
             <div class="font-semibold text-sm text-sidebarTextColor p-1 w-2/12 text-start">$ <%= number_with_delimiter(article.price.round(2), :delimiter => ',') %> MXN</div>
-            <div class="font-semibold text-sm text-sidebarTextColor p-1 w-1/12 flex items-center justify-center">
-              <% if article.in_stock > 0 %>
-                <div class="w-3 h-3 rounded-full bg-success"></div>
-              <% else %>
-                <div class="w-3 h-3 rounded-full bg-danger"></div>
-              <% end %>
-            </div>
-            <div class="font-semibold text-sm text-sidebarTextColor p-1 w-1/12 text-center"><%= article.in_stock %></div>
           <% end %>
         <% end %>
       </div>

--- a/app/views/articles/_filter_form.html.erb
+++ b/app/views/articles/_filter_form.html.erb
@@ -11,7 +11,7 @@
   </div>
 
   <div class="flex w-full gap-2">
-    <div class="flex flex-col items-start w-4/12">
+    <div class="flex flex-col items-start w-4/12 gap-2">
       <%= f.label :cateogry, 'Categoria:', class: 'font-semibold text-sidebarTextColor w-1/2' %>
       <%= f.select(:category, Category.all.order(:name).map { |option| [option.name, option.id] }, { include_blank: 'Mostrar todos los articulos' }, { class: "input-tailwindcss #{ error_input_border(filter_form.errors.include?(:category)) }" }) %>
       <% if filter_form.errors.include?(:category) %>
@@ -19,7 +19,7 @@
       <% end %>
     </div>
 
-    <div class="flex flex-col items-start w-4/12">
+    <div class="flex flex-col items-start w-4/12 gap-2">
       <%= f.label :min_price, 'Precio mínimo:', class: 'font-semibold text-sidebarTextColor w-1/2' %>
       <%= f.number_field :min_price, step: :any, min: 0, class: "input-tailwindcss #{ error_input_border(filter_form.errors.include?(:min_price)) }" %>
       <% if filter_form.errors.include?(:min_price) %>
@@ -27,7 +27,7 @@
       <% end %>
     </div>
 
-    <div class="flex flex-col items-start w-4/12">
+    <div class="flex flex-col items-start w-4/12 gap-2">
       <%= f.label :max_price, 'Precio máximo:', class: 'font-semibold text-sidebarTextColor w-1/2' %>
       <%= f.number_field :max_price, step: :any, min: 0, class: "input-tailwindcss #{ error_input_border(filter_form.errors.include?(:max_price)) }" %>
       <% if filter_form.errors.include?(:max_price) %>

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -18,15 +18,7 @@
   </div>
 
   <div class="flex flex-col gap-1 w-full items-start">
-    <%= form.label :in_stock, 'Cantidad disponibles en almacén:', class: 'font-bold mb-1' %>
-    <%= form.number_field :in_stock, class: "input-tailwindcss font-semibold #{ error_input_border(article.errors.include?(:in_stock)) }" %>
-    <% if article.errors.include?(:in_stock) %>
-      <%= render 'shared/input_error_msg', { object: article, attribute: :in_stock } %>
-    <% end %>
-  </div>
-
-  <div class="flex flex-col gap-1 w-full items-start">
-    <%= form.label :description, 'Descripción del artículo:', class: 'font-bold mb-1' %>
+    <%= form.label :description, 'Descripción del artículo (opcional):', class: 'font-bold mb-1' %>
     <%= form.rich_text_area :description, class: "input-tailwindcss #{ error_input_border(article.errors.include?(:description)) } h-40 overflow-y-auto" %>
     <% if article.errors.include?(:description) %>
       <%= render 'shared/input_error_msg', { object: article, attribute: :description } %>
@@ -38,7 +30,7 @@
       <%= form.label :avatar, 'Imagen principal del articulo (opcional):', class: 'font-bold mb-1' %>
       <%= form.file_field :avatar, class: "hidden", accept: "image/png,image/gif,image/jpeg,image/jpg",  multiple: false %>
       <div data-action="click->article#addAvatar" class="flex items-center cursor-pointer border rounded-lg shadow w-full">
-        <span class="bg-slate-400 py-1.5 px-3 font-semibold text-white w-4/12 text-sm rounded-l-lg">Seleccionar imagen</span>
+        <span class="bg-slate-400 py-1.5 px-3 font-semibold text-white w-1/2 text-sm rounded-l-lg">Seleccionar imagen</span>
         <span class="py-1.5 px-3 bg-slate-700 text-white font-semibold w-full text-sm rounded-r-lg" id="avatar_name">Ningún archivo seleccionado</span>
       </div>
       <% if article.errors.include?(:avatar) %>
@@ -47,25 +39,12 @@
     </div>
 
     <div class="flex flex-col gap-1 w-full items-start" data-controller="article">
-      <%= form.label :promotional_video, 'Video del articulo (opcional):', class: 'font-bold mb-1' %>
-      <%= form.file_field :promotional_video, class: "hidden", accept: 'video/mp4,video/webm', multiple: false %>
-      <div data-action="click->article#addPromotionalVideo" class="flex items-center cursor-pointer border rounded-lg shadow w-full">
-        <span class="bg-slate-400 py-1.5 px-3 font-semibold text-white w-4/12 text-sm rounded-l-lg">Seleccionar imagen</span>
-        <span class="py-1.5 px-3 bg-slate-700 text-white font-semibold w-full text-sm rounded-r-lg" id="promotional_video_name">Ningún archivo seleccionado</span>
+      <%= form.label :images, 'Añadir más imagenes (opcional):', class: 'font-bold mb-1' %>
+      <%= form.file_field :images, class: 'hidden', accept: "image/png,image/gif,image/jpeg,image/jpg", multiple: true %>
+      <div data-action="click->article#addImages" class="flex items-center cursor-pointer border rounded-lg shadow w-full">
+        <span class="bg-slate-400 py-1.5 px-3 font-semibold text-white w-1/2 text-sm rounded-l-lg">Seleccionar imagenes</span>
+        <span class="py-1.5 px-3 bg-slate-700 text-white font-semibold w-full text-sm rounded-r-lg" id="images_name">Ningún archivo seleccionado</span>
       </div>
-      <% if article.errors.include?(:promotional_video) %>
-        <%= render 'shared/input_error_msg', { object: article, attribute: :promotional_video } %>
-      <% end %>
-    </div>
-  </div>
-
-
-  <div class="flex flex-col gap-1 w-full items-start" data-controller="article">
-    <%= form.label :images, 'Añadir más imagenes (opcional):', class: 'font-bold mb-1' %>
-    <%= form.file_field :images, class: 'hidden', accept: "image/png,image/gif,image/jpeg,image/jpg", multiple: true %>
-    <div data-action="click->article#addImages" class="flex items-center cursor-pointer border rounded-lg shadow w-full">
-      <span class="bg-slate-400 py-1.5 px-3 font-semibold text-white w-3/12 text-sm rounded-l-lg">Seleccionar imagenes</span>
-      <span class="py-1.5 px-3 bg-slate-700 text-white font-semibold w-full text-sm rounded-r-lg" id="images_name">Ningún archivo seleccionado</span>
     </div>
   </div>
 
@@ -79,3 +58,16 @@
     <% end %>
   </div>
 <% end %>
+
+
+<%# <div class="flex flex-col gap-1 w-full items-start" data-controller="article"> %>
+  <%#= form.label :promotional_video, 'Video del articulo (opcional):', class: 'font-bold mb-1' %>
+  <%#= form.file_field :promotional_video, class: "hidden", accept: 'video/mp4,video/webm', multiple: false %>
+  <%# <div data-action="click->article#addPromotionalVideo" class="flex items-center cursor-pointer border rounded-lg shadow w-full"> %>
+    <%# <span class="bg-slate-400 py-1.5 px-3 font-semibold text-white w-4/12 text-sm rounded-l-lg">Seleccionar imagen</span> %>
+    <%# <span class="py-1.5 px-3 bg-slate-700 text-white font-semibold w-full text-sm rounded-r-lg" id="promotional_video_name">Ningún archivo seleccionado</span> %>
+  <%# </div> %>
+  <%# if article.errors.include?(:promotional_video) %>
+    <%#= render 'shared/input_error_msg', { object: article, attribute: :promotional_video } %>
+  <%# end %>
+<%# </div> %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,6 +1,8 @@
 <section class="flex flex-col h-full w-full">
   <%= render 'shared/navbar' do %>
-    <h1 class="font-bold text-2xl text-sidebarTextColor">Articulos</h1>
+    <%= link_to articles_path, class: 'flex items-center' do %>
+      <h1 class="font-bold text-2xl text-sidebarTextColor">Articulos</h1>
+    <% end %>
 
     <div class="flex items-center gap-5">
       <%= render 'search_form' %>

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -1,19 +1,21 @@
 <div class="flex flex-col h-full w-full">
   <%= render 'shared/navbar' do %>
-    <h1 class="font-bold text-2xl text-sidebarTextColor">Dashboard</h1>
+    <%= link_to root_path, class: 'flex items-center' do %>
+      <h1 class="font-bold text-2xl text-sidebarTextColor">Dashboard</h1>
+    <% end %>
   <% end %>
 
   <div class="flex flex-col w-full p-5 gap-5">
     <div class="flex items-center justify-center gap-12">
-      <%= render 'pages/dashboard/card', { title: 'Ganancias', text: "$ #{number_with_delimiter(@revenue, :delimiter => ',')} MXN" } %>
-      <%= render 'pages/dashboard/card', { title: 'Ventas totales', text: @sells.count } %>
-      <%= render 'pages/dashboard/card', { title: 'Número de articulos', text: @articles.count } %>
+      <%#= render 'pages/dashboard/card', { title: 'Ganancias', text: "$ #{number_with_delimiter(@revenue, :delimiter => ',')} MXN" } %>
+      <%#= render 'pages/dashboard/card', { title: 'Ventas totales', text: @sells.count } %>
+      <%#= render 'pages/dashboard/card', { title: 'Número de articulos', text: @articles.count } %>
     </div>
 
     <div class="flex w-full p-5 rounded bg-white shadow border gap-5">
-      <%= render 'pages/dashboard/chart', { title: 'Ventas en los últimos 30 días' } do %>
-        <%= line_chart Sell.latest_sells, colors: ["#1B9C85"], xtitle: "Días", ytitle: "Ganancias", curve: false, prefix: "$", thousands: ",", round: 2, zeros: true, loading: "Cargando..." %>
-      <% end %>
+      <%#= render 'pages/dashboard/chart', { title: 'Ventas en los últimos 30 días' } do %>
+        <%#= line_chart Sell.latest_sells, colors: ["#1B9C85"], xtitle: "Días", ytitle: "Ganancias", curve: false, prefix: "$", thousands: ",", round: 2, zeros: true, loading: "Cargando..." %>
+      <%# end %>
     </div>
 
     <div class="flex w-full gap-5">
@@ -25,13 +27,13 @@
           <div class="w-1/6 text-sidebarTextColor font-bold text-center">Ventas</div>
         </div>
         <div class="flex flex-col w-full gap-1">
-          <% @articles.order(sells_count: :desc).limit(5).each do |article| %>
+          <%# @articles.order(sells_count: :desc).limit(5).each do |article| %>
             <div class="flex items-center w-full border-b py-1">
-              <div class="w-3/6 text-sidebarTextColor font-semibold text-sm"><%= article.name %></div>
-              <div class="w-2/6 text-sidebarTextColor font-semibold text-sm">$ <%= number_with_delimiter(article.price.round(2), :delimiter => ',') %> MXN</div>
-              <div class="w-1/6 text-sidebarTextColor font-semibold text-sm text-center"><%= article.sells.count %></div>
+              <div class="w-3/6 text-sidebarTextColor font-semibold text-sm"><%#= article.name %></div>
+              <div class="w-2/6 text-sidebarTextColor font-semibold text-sm">$ <%#= number_with_delimiter(article.price.round(2), :delimiter => ',') %> MXN</div>
+              <div class="w-1/6 text-sidebarTextColor font-semibold text-sm text-center"><%#= article.sells.count %></div>
             </div>
-          <% end %>
+          <%# end %>
         </div>
       </div>
 
@@ -43,13 +45,13 @@
           <div class="w-1/6 text-sidebarTextColor font-bold text-center">Cantidad</div>
         </div>
         <div class="flex flex-col w-full gap-1">
-          <% @sells.order(date_of_sell: :desc).limit(5).each do |sell| %>
+          <%# @sells.order(date_of_sell: :desc).limit(5).each do |sell| %>
             <div class="flex items-center w-full border-b py-1">
-              <div class="w-1/6 text-sidebarTextColor font-semibold text-sm"><%= sell.id %></div>
-              <div class="w-4/6 text-sidebarTextColor font-semibold text-sm"><%= I18n.l(sell.date_of_sell.to_time, format: :long) %></div>
-              <div class="w-1/6 text-sidebarTextColor font-semibold text-sm text-center"><%= sell.quantity %></div>
+              <div class="w-1/6 text-sidebarTextColor font-semibold text-sm"><%#= sell.id %></div>
+              <div class="w-4/6 text-sidebarTextColor font-semibold text-sm"><%#= I18n.l(sell.date_of_sell.to_time, format: :long) %></div>
+              <div class="w-1/6 text-sidebarTextColor font-semibold text-sm text-center"><%#= sell.quantity %></div>
             </div>
-          <% end %>
+          <%# end %>
         </div>
       </div>
     </div>

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -14,7 +14,7 @@
 
     <div class="flex w-full p-5 rounded bg-white shadow border gap-5">
       <%= render 'pages/dashboard/chart', { title: 'Ventas en los últimos 30 días' } do %>
-        <%= line_chart Sell.latest_sells, colors: ["#1B9C85"], xtitle: "Días", ytitle: "Ganancias", curve: false, prefix: "$", thousands: ",", round: 2, zeros: true, loading: "Cargando..." %>
+        <%= line_chart Sell.revenue_by_day, colors: ["#1B9C85"], xtitle: "Días", ytitle: "Ganancias", curve: false, prefix: "$", thousands: ",", round: 2, zeros: true, loading: "Cargando..." %>
       <% end %>
     </div>
 
@@ -22,16 +22,16 @@
       <div class="flex flex-col w-1/2 p-5 rounded bg-white shadow border gap-5">
         <h5 class="font-bold text-lg text-sidebarTextColor">Últimos articulos añadidos</h5>
         <div class="flex w-full bg-gray-100 rounded">
-          <div class="w-3/6 text-sidebarTextColor font-bold">Nombre</div>
-          <div class="w-2/6 text-sidebarTextColor font-bold">Precio unitario</div>
-          <div class="w-1/6 text-sidebarTextColor font-bold text-center">Ventas</div>
+          <div class="w-6/12 text-sidebarTextColor font-bold">Nombre</div>
+          <div class="w-3/12 text-sidebarTextColor font-bold">Precio unitario</div>
+          <div class="w-3/12 text-sidebarTextColor font-bold text-center">Ventas por pieza</div>
         </div>
         <div class="flex flex-col w-full gap-1">
           <% @articles.order(created_at: :desc).limit(5).each do |article| %>
             <div class="flex items-center w-full border-b py-1">
-              <div class="w-3/6 text-sidebarTextColor font-semibold text-sm"><%= article.name %></div>
-              <div class="w-2/6 text-sidebarTextColor font-semibold text-sm">$ <%= number_with_delimiter(article.price.round(2), :delimiter => ',') %> MXN</div>
-              <div class="w-1/6 text-sidebarTextColor font-semibold text-sm text-center"><%= ArticleSell.calculate_articles_quantity(article.id) %></div>
+              <div class="w-6/12 text-sidebarTextColor font-semibold text-sm"><%= article.name %></div>
+              <div class="w-3/12 text-sidebarTextColor font-semibold text-sm">$ <%= number_with_delimiter(article.price.round(2), :delimiter => ',') %> MXN</div>
+              <div class="w-3/12 text-sidebarTextColor font-semibold text-sm text-center"><%= article.article_sells.sum(:quantity) %></div>
             </div>
           <% end %>
         </div>

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -7,51 +7,57 @@
 
   <div class="flex flex-col w-full p-5 gap-5">
     <div class="flex items-center justify-center gap-12">
-      <%#= render 'pages/dashboard/card', { title: 'Ganancias', text: "$ #{number_with_delimiter(@revenue, :delimiter => ',')} MXN" } %>
-      <%#= render 'pages/dashboard/card', { title: 'Ventas totales', text: @sells.count } %>
-      <%#= render 'pages/dashboard/card', { title: 'Número de articulos', text: @articles.count } %>
+      <%= render 'pages/dashboard/card', { title: 'Ganancias', text: "$ #{number_with_delimiter(@revenue, :delimiter => ',')} MXN" } %>
+      <%= render 'pages/dashboard/card', { title: 'Ventas totales', text: @sells.count } %>
+      <%= render 'pages/dashboard/card', { title: 'Número de articulos', text: @articles.count } %>
     </div>
 
     <div class="flex w-full p-5 rounded bg-white shadow border gap-5">
-      <%#= render 'pages/dashboard/chart', { title: 'Ventas en los últimos 30 días' } do %>
-        <%#= line_chart Sell.latest_sells, colors: ["#1B9C85"], xtitle: "Días", ytitle: "Ganancias", curve: false, prefix: "$", thousands: ",", round: 2, zeros: true, loading: "Cargando..." %>
-      <%# end %>
+      <%= render 'pages/dashboard/chart', { title: 'Ventas en los últimos 30 días' } do %>
+        <%= line_chart Sell.latest_sells, colors: ["#1B9C85"], xtitle: "Días", ytitle: "Ganancias", curve: false, prefix: "$", thousands: ",", round: 2, zeros: true, loading: "Cargando..." %>
+      <% end %>
     </div>
 
     <div class="flex w-full gap-5">
       <div class="flex flex-col w-1/2 p-5 rounded bg-white shadow border gap-5">
-        <h5 class="font-bold text-lg text-sidebarTextColor">Los 5 Articulos con más ventas</h5>
+        <h5 class="font-bold text-lg text-sidebarTextColor">Últimos articulos añadidos</h5>
         <div class="flex w-full bg-gray-100 rounded">
           <div class="w-3/6 text-sidebarTextColor font-bold">Nombre</div>
           <div class="w-2/6 text-sidebarTextColor font-bold">Precio unitario</div>
           <div class="w-1/6 text-sidebarTextColor font-bold text-center">Ventas</div>
         </div>
         <div class="flex flex-col w-full gap-1">
-          <%# @articles.order(sells_count: :desc).limit(5).each do |article| %>
+          <% @articles.order(created_at: :desc).limit(5).each do |article| %>
             <div class="flex items-center w-full border-b py-1">
-              <div class="w-3/6 text-sidebarTextColor font-semibold text-sm"><%#= article.name %></div>
-              <div class="w-2/6 text-sidebarTextColor font-semibold text-sm">$ <%#= number_with_delimiter(article.price.round(2), :delimiter => ',') %> MXN</div>
-              <div class="w-1/6 text-sidebarTextColor font-semibold text-sm text-center"><%#= article.sells.count %></div>
+              <div class="w-3/6 text-sidebarTextColor font-semibold text-sm"><%= article.name %></div>
+              <div class="w-2/6 text-sidebarTextColor font-semibold text-sm">$ <%= number_with_delimiter(article.price.round(2), :delimiter => ',') %> MXN</div>
+              <div class="w-1/6 text-sidebarTextColor font-semibold text-sm text-center"><%= ArticleSell.calculate_articles_quantity(article.id) %></div>
             </div>
-          <%# end %>
+          <% end %>
         </div>
       </div>
 
       <div class="flex flex-col w-1/2 p-5 rounded bg-white shadow border gap-5">
-        <h5 class="font-bold text-lg text-sidebarTextColor">Las 5 ventas más recientes</h5>
+        <h5 class="font-bold text-lg text-sidebarTextColor">Ventas más recientes</h5>
         <div class="flex w-full bg-gray-100 rounded">
-          <div class="w-1/6 text-sidebarTextColor font-bold">ID</div>
-          <div class="w-4/6 text-sidebarTextColor font-bold">Fecha</div>
-          <div class="w-1/6 text-sidebarTextColor font-bold text-center">Cantidad</div>
+          <div class="w-1/12 text-sidebarTextColor font-bold">ID</div>
+          <div class="w-6/12 text-sidebarTextColor font-bold">Fecha</div>
+          <div class="w-5/12 text-sidebarTextColor font-bold">Descripción</div>
         </div>
         <div class="flex flex-col w-full gap-1">
-          <%# @sells.order(date_of_sell: :desc).limit(5).each do |sell| %>
+          <% @sells.order(date_of_sell: :desc).limit(5).each do |sell| %>
             <div class="flex items-center w-full border-b py-1">
-              <div class="w-1/6 text-sidebarTextColor font-semibold text-sm"><%#= sell.id %></div>
-              <div class="w-4/6 text-sidebarTextColor font-semibold text-sm"><%#= I18n.l(sell.date_of_sell.to_time, format: :long) %></div>
-              <div class="w-1/6 text-sidebarTextColor font-semibold text-sm text-center"><%#= sell.quantity %></div>
+              <div class="w-1/12 text-sidebarTextColor font-semibold text-sm"><%= sell.id %></div>
+              <div class="w-6/12 text-sidebarTextColor font-semibold text-sm"><%= I18n.l(sell.date_of_sell.to_time, format: :long) %></div>
+              <div class="w-5/12 text-sidebarTextColor font-semibold text-sm">
+                <% if sell.description.present? %>
+                  <%= sell.description.length > 30 ? "#{sell.description[0..30]..}" : sell.description %>
+                <% else %>
+                  --
+                <% end %>
+              </div>
             </div>
-          <%# end %>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/pages/dashboard/_card.html.erb
+++ b/app/views/pages/dashboard/_card.html.erb
@@ -1,6 +1,6 @@
 <div class="flex flex-col gap-2 rounded-lg p-8 bg-white shadow border w-4/12">
   <h6 class="text-end font-semibold text-sidebarTextColor"><%= title %></h6>
-  <p class="text-end font-semibold text-4xl">
+  <p class="text-end font-semibold text-3xl">
     <%= text %>
   </p>
 </div>

--- a/app/views/sells/_filter_form.html.erb
+++ b/app/views/sells/_filter_form.html.erb
@@ -11,15 +11,7 @@
   </div>
 
   <div class="flex w-full gap-2">
-    <div class="flex flex-col items-start w-2/6">
-      <%= f.label :article_id, 'Articulo:', class: 'font-semibold text-sidebarTextColor' %>
-      <%= f.select(:article_id, Article.all.order(:name).map { |option| [option.name, option.id] }, { include_blank: 'Mostrar todas las ventas' }, { class: "input-tailwindcss #{ error_input_border(sells_filter.errors.include?(:article_id)) }", id: 'select_name'}) %>
-      <% if sells_filter.errors.include?(:article_id) %>
-        <%= render 'shared/input_error_msg', { object: sells_filter, attribute: :article_id } %>
-      <% end %>
-    </div>
-
-    <div class="flex flex-col items-start w-2/6">
+    <div class="flex flex-col items-start w-3/6 gap-2">
       <%= f.label :date_min, 'Fecha inicial:', class: 'font-semibold text-sidebarTextColor' %>
       <%= f.date_field :date_min, class: "input-tailwindcss #{ error_input_border(sells_filter.errors.include?(:date_min)) }" %>
       <% if sells_filter.errors.include?(:date_min) %>
@@ -27,7 +19,7 @@
       <% end %>
     </div>
 
-    <div class="flex flex-col items-start w-2/6">
+    <div class="flex flex-col items-start w-3/6 gap-2">
       <%= f.label :date_max, 'Fecha final:', class: 'font-semibold text-sidebarTextColor' %>
       <%= f.date_field :date_max, class: "input-tailwindcss #{ error_input_border(sells_filter.errors.include?(:date_max)) }" %>
       <% if sells_filter.errors.include?(:date_max) %>

--- a/app/views/sells/_filter_form.html.erb
+++ b/app/views/sells/_filter_form.html.erb
@@ -34,13 +34,5 @@
         <%= render 'shared/input_error_msg', { object: sells_filter, attribute: :date_max } %>
       <% end %>
     </div>
-
-    <div class="flex flex-col items-start w-2/6">
-      <%= f.label :quantity, 'Cantidad:', class: 'font-semibold text-sidebarTextColor' %>
-      <%= f.number_field :quantity, class: "input-tailwindcss #{ error_input_border(sells_filter.errors.include?(:quantity)) }" %>
-      <% if sells_filter.errors.include?(:quantity) %>
-        <%= render 'shared/input_error_msg', { object: sells_filter, attribute: :quantity } %>
-      <% end %>
-    </div>
   </div>
 <% end %>

--- a/app/views/sells/_form.html.erb
+++ b/app/views/sells/_form.html.erb
@@ -1,50 +1,21 @@
-<%= form_with(model: sell, class: "flex flex-col w-full gap-5") do |form| %>
-  <div class="flex items-start gap-2">
-    <div class="flex flex-col gap-1 w-6/12 items-start">
-      <%= form.label :article_id, 'Seleccionar articulo:', class: 'font-bold mb-1' %>
-      <%= form.select(:article_id, articles.order(:name).map { |option| [option.name_with_in_stock, option.id] },
-          { include_blank: true },
-          { class: "input-tailwindcss font-semibold #{ error_input_border(sell.errors.include?(:article)) }", id: 'select_name'
-        }) %>
-      <% if sell.errors.include?(:article) %>
-        <%= render 'shared/input_error_msg', { object: sell, attribute: :article } %>
-      <% end %>
-    </div>
-
-    <div class="flex flex-col gap-1 w-6/12 items-start">
-      <%= form.label :quantity, 'Total de piezas a vender:', class: 'font-bold mb-1' %>
-      <%= form.number_field :quantity, class: "input-tailwindcss font-semibold #{ error_input_border(sell.errors.include?(:quantity)) }" %>
-      <% if sell.errors.include?(:quantity) %>
-        <%= render 'shared/input_error_msg', { object: sell, attribute: :quantity } %>
-      <% end %>
-    </div>
-  </div>
-
-  <div class="flex items-start gap-2">
-    <div class="flex flex-col gap-1 w-6/12 items-start">
-      <%= form.label :date_of_sell, 'Fecha de venta:', class: 'font-bold mb-1' %>
-      <%= form.date_field :date_of_sell, class: "input-tailwindcss font-semibold #{ error_input_border(sell.errors.include?(:date_of_sell)) }" %>
-      <% if sell.errors.include?(:date_of_sell) %>
-        <%= render 'shared/input_error_msg', { object: sell, attribute: :date_of_sell } %>
-      <% end %>
-    </div>
-  </div>
-
-  <div class="flex flex-col gap-1 items-start">
-    <%= form.label :comment, 'Comentario (opcional):', class: 'font-bold mb-1' %>
-    <%= form.text_field :comment, class: "input-tailwindcss font-semibold #{ error_input_border(sell.errors.include?(:comment)) }" %>
-    <% if sell.errors.include?(:comment) %>
-      <%= render 'shared/input_error_msg', { object: sell, attribute: :comment } %>
+<%= form_with(model: sell, id: id, class: "flex flex-col w-full gap-5") do |form| %>
+  <div class="flex flex-col gap-1 w-full items-start">
+    <%= form.label :date_of_sell, 'Fecha de venta:', class: 'font-bold mb-1' %>
+    <%= form.date_field :date_of_sell, class: "input-tailwindcss font-semibold #{ error_input_border(sell.errors.include?(:date_of_sell)) }" %>
+    <% if sell.errors.include?(:date_of_sell) %>
+      <%= render 'shared/input_error_msg', { object: sell, attribute: :date_of_sell } %>
     <% end %>
   </div>
 
-  <div class="flex items-center justify-end gap-3">
-    <div class="flex items-center text-sm font-semibold">
-      <%= form.submit btn_title, class: "rounded py-2 px-4 bg-green-500 text-white font-semibold cursor-pointer" %>
-    </div>
-
-    <%= link_to cancel_path, class: "flex text-sm font-semibold rounded bg-danger px-4 py-2 text-white items-center gap-1" do %>
-      <span>Regresar</span>
+  <div class="flex flex-col gap-1 w-full items-start">
+    <%= form.label :description, 'Descripción de la venta:', class: 'font-bold mb-1' %>
+    <%= form.text_field :description, class: "input-tailwindcss font-semibold #{ error_input_border(sell.errors.include?(:description)) }" %>
+    <% if sell.errors.include?(:description) %>
+      <%= render 'shared/input_error_msg', { object: sell, attribute: :description } %>
     <% end %>
+  </div>
+
+  <div class="flex items-center justify-end gap-3 mt-5">
+    <%= form.submit btn_text, class: "rounded py-2 px-4 bg-green-500 text-white font-semibold cursor-pointer", data: { turbo_frame: '_top' } %>
   </div>
 <% end %>

--- a/app/views/sells/_sell.html.erb
+++ b/app/views/sells/_sell.html.erb
@@ -1,80 +1,31 @@
-<div class="flex flex-col w-1/2 gap-5 border shadow p-5 bg-white rounded">
-  <%= render 'shared/breadcumb', { path: sells_path, path_text: 'Ventas', text: "Venta de: #{sell.article.name}" } %>
+<div class="flex flex-col w-full gap-5 border shadow p-5 bg-white rounded">
+  <div class="flex items-center justify-between">
+    <%= render 'shared/breadcumb', { path: sells_path, path_text: 'Ventas', text: "Venta No. #{sell.id}" } %>
 
-  <div class="flex gap-2 items-center">
-    <span class="font-regular text-sidebarTextColor">ID de la venta:</span>
-    <span class="font-semibold"><%= sell.id %></span>
-  </div>
-
-  <div class="flex gap-5 items-center w-full">
-    <span class="font-regular text-sidebarTextColor">Opciones:</span>
-
-    <%= link_to edit_sell_path(@sell), class: "text-lg font-semibold underline gap-2 flex items-center text-primary hover:text-cyan-800 duration-300" do %>
-      <i class="fa-solid fa-pen-to-square"></i>
-      <span class="text-base">Editar</span>
-    <% end %>
-    <%= button_to sell_path(@sell), method: :delete, form: { data: { turbo_confirm: 'Estas seguro de eliminar esta venta?' } }, class: "text-lg font-semibold underline gap-2 flex items-center text-danger hover:text-red-800 duration-300" do %>
-      <i class="fa-solid fa-trash"></i>
-      <span class="text-base">Eliminar</span>
-    <% end %>
-  </div>
-
-  <div class="flex gap-2 items-center">
-    <span class="font-regular text-sidebarTextColor">Cantidad de articulos vendidos:</span>
-    <span class="font-semibold"><%= sell.quantity %> (pz)</span>
-  </div>
-
-  <div class="flex gap-2 items-center">
-    <span class="font-regular text-sidebarTextColor">Fecha de la venta:</span>
-    <span class="font-semibold"><%= I18n.l(sell.date_of_sell.to_time, format: :long) %></span>
-  </div>
-
-  <div class="flex gap-2 items-center">
-    <span class="font-regular text-sidebarTextColor">Total de ingresos:</span>
-    $<span class="font-semibold"><%= number_with_delimiter(sell.total_revenue.round(2), :delimiter => ',') %></span> MXN
-  </div>
-
-  <div class="flex flex-col">
-    <span class="font-regular text-sidebarTextColor">Comentario de la venta (opcional):</span>
-    <span class="font-semibold">
-      <% if sell.comment.blank? %>
-        Sin comentarios
-      <% else %>
-        <%= sell.comment %>
+    <div class="flex items-center gap-5">
+      <%= link_to edit_sell_path(@sell), data: { turbo_frame: 'edit_sell' },class: "text-lg font-semibold gap-2 flex items-center text-primary hover:text-cyan-800 duration-300" do %>
+        <i class="fa-solid fa-pen-to-square"></i>
       <% end %>
-    </span>
-  </div>
-</div>
-
-<div class="bg-white flex flex-col w-1/2 border shadow items-center justify-center gap-5 p-5 rounded">
-  <div class="flex w-full items-center">
-    <h6 class="font-semibold text-sidebarTextColor">Información del artículo</h6>
+      <%= button_to sell_path(@sell), method: :delete, form: { data: { turbo_confirm: 'Estas seguro de eliminar esta venta?' } }, class: "text-lg font-semibold gap-2 flex items-center text-danger hover:text-red-800 duration-300" do %>
+        <i class="fa-solid fa-trash"></i>
+      <% end %>
+    </div>
   </div>
 
-  <div class="flex items-center justify-center">
-    <% if sell.article.avatar.attached? %>
-      <%= image_tag(sell.article.avatar, class: 'w-40 h-40 rounded-full shadow-lg shadow-slate-400 border object-contain') %>
-    <% else %>
-      <div class="w-40 h-40 shadow shadow-slate-400 rounded-full border bg-gradient-to-br from-cyan-300 to-green-300"></div>
-    <% end %>
-  </div>
+  <div class="flex flex-col w-full gap-1">
+    <div class="flex gap-2 items-center">
+      <span class="font-regular text-sidebarTextColor">ID de la venta:</span>
+      <span class="font-semibold"><%= sell.id %></span>
+    </div>
 
-  <div class="flex gap-2 items-center full">
-    <span class="font-regular text-sidebarTextColor">Nombre del articulo:</span>
-    <%= link_to article_path(sell.article) do %>
-      <span class="font-bold text-cyan-600 underline"><%= sell.article.name %></span>
-    <% end %>
-  </div>
+    <div class="flex gap-2 items-center">
+      <span class="font-regular text-sidebarTextColor">Fecha de la venta:</span>
+      <span class="font-semibold"><%= I18n.l(sell.date_of_sell.to_time, format: :long) %></span>
+    </div>
 
-  <div class="flex gap-2 items-center">
-    <span class="font-regular text-sidebarTextColor">Precio del articulo:</span>
-    $<span class="font-semibold"><%= number_with_delimiter(sell.article.price.round(2), :delimiter => ',') %></span> MXN
-  </div>
-
-  <div class="flex gap-2 items-center">
-    <span class="font-regular text-sidebarTextColor">Categoria(s):</span>
-    <% sell.article.categories.each do |category| %>
-      <span class="text-xs text-white py-1   px-3 rounded-xl bg-yellow-600"><%= category.name %></span>
-    <% end %>
+    <div class="flex gap-2 items-center">
+      <span class="font-regular text-sidebarTextColor">Descripción del venta:</span>
+      <span class="font-semibold"><%= sell.description.present? ? sell.description : '--' %></span>
+    </div>
   </div>
 </div>

--- a/app/views/sells/_sells.html.erb
+++ b/app/views/sells/_sells.html.erb
@@ -5,22 +5,18 @@
     <div class="flex flex-col w-full gap-2">
       <div class="flex w-full bg-gray-100 rounded">
         <div class="w-1/12 p-1 font-bold text-sidebarTextColor">ID</div>
-        <div class="w-3/12 p-1 font-bold text-sidebarTextColor">Articulo</div>
-        <div class="w-3/12 p-1 font-bold text-sidebarTextColor">Fecha</div>
-        <div class="w-1/12 p-1 font-bold text-sidebarTextColor text-center">Cantidad</div>
-        <div class="w-2/12 p-1 font-bold text-sidebarTextColor text-end">Precio unitario</div>
-        <div class="w-2/12 p-1 font-bold text-sidebarTextColor text-end">Total</div>
+        <div class="w-4/12 p-1 font-bold text-sidebarTextColor">Fecha de la venta</div>
+        <div class="w-5/12 p-1 font-bold text-sidebarTextColor">Descripción</div>
+        <div class="w-2/12 p-1 font-bold text-sidebarTextColor">No. de artículos</div>
       </div>
 
       <div class="flex flex-col w-full">
         <% sells.each do |sell| %>
           <%= link_to sell_path(sell), class: 'flex items-center w-full hover:bg-gray-100 p-1 duration-300 border-b' do %>
             <div class="font-semibold text-sm text-sidebarTextColor p-1 w-1/12"><%= sell.id %></div>
-            <div class="font-semibold text-sm text-sidebarTextColor p-1 w-3/12"><%= sell.article.name %></div>
-            <div class="font-semibold text-sm text-sidebarTextColor p-1 w-3/12"><%= I18n.l(sell.date_of_sell.to_time, format: :long) %></div>
-            <div class="font-semibold text-sm text-sidebarTextColor p-1 w-1/12 text-center"><%= sell.quantity %></div>
-            <div class="font-semibold text-sm text-sidebarTextColor p-1 w-2/12 text-end">$ <%= number_with_delimiter(sell.article.price.round(2), :delimiter => ',') %> MXN</div>
-            <div class="font-semibold text-sm text-sidebarTextColor p-1 w-2/12 text-end">$ <%= number_with_delimiter(sell.total_revenue.round(2), :delimiter => ',') %> MXN</div>
+            <div class="font-semibold text-sm text-sidebarTextColor p-1 w-4/12"><%= I18n.l(sell.date_of_sell.to_time, format: :long) %></div>
+            <div class="font-semibold text-sm text-sidebarTextColor p-1 w-5/12"><%= sell.description.present? ? sell.description : '--' %></div>
+            <div class="font-semibold text-sm text-sidebarTextColor p-1 w-2/12"><%= sell.articles.count %></div>
           <% end %>
         <% end %>
       </div>

--- a/app/views/sells/edit.html.erb
+++ b/app/views/sells/edit.html.erb
@@ -1,11 +1,5 @@
-<section class="flex flex-col h-full w-full">
-  <%= render 'shared/navbar' do %>
-    <h1 class="font-bold text-2xl text-sidebarTextColor">Actualizar venta</h1>
+<%= turbo_frame_tag 'edit_sell', class:"flex flex-col w-full" do %>
+  <%= render 'shared/modal', { title: "Editar: Venta #{@sell.id}" } do %>
+    <%= render 'form', { sell: @sell, id: 'edit_sell_form', btn_text: 'Actualizar' } %>
   <% end %>
-
-  <div class="flex flex-col overflow-y-auto p-5 gap-10 m-5 bg-white border rounded shadow">
-    <%= render 'shared/breadcumb', { path: sell_path(@sell), path_text: "Venta de: #{@sell.article.name}", text: 'Actualizar venta' } %>
-
-    <%= render "form", { sell: @sell, btn_title: 'Actualizar', cancel_path: sell_path(@sell), articles: Article.all } %>
-  </div>
-</section>
+<% end %>

--- a/app/views/sells/index.html.erb
+++ b/app/views/sells/index.html.erb
@@ -1,10 +1,12 @@
+<%= turbo_frame_tag 'new_sell' %>
+
 <div class="flex flex-col h-full w-full">
   <%= render 'shared/navbar' do %>
     <%= link_to sells_path, class: 'flex items-center' do %>
       <h1 class="font-bold text-2xl text-sidebarTextColor">Ventas</h1>
     <% end %>
 
-    <%= link_to new_sell_path, class: "flex text-sm font-bold rounded bg-success px-4 py-2 text-white items-center gap-2" do %>
+    <%= link_to new_sell_path, class: "flex text-sm font-bold rounded bg-success px-4 py-2 text-white items-center gap-2", data: { turbo_frame: 'new_sell' } do %>
       <span>Añadir venta</span>
       <i class="fa-solid fa-plus text-base"></i>
     <% end %>

--- a/app/views/sells/index.html.erb
+++ b/app/views/sells/index.html.erb
@@ -1,6 +1,8 @@
 <div class="flex flex-col h-full w-full">
   <%= render 'shared/navbar' do %>
-    <h1 class="font-bold text-2xl text-sidebarTextColor">Ventas</h1>
+    <%= link_to sells_path, class: 'flex items-center' do %>
+      <h1 class="font-bold text-2xl text-sidebarTextColor">Ventas</h1>
+    <% end %>
 
     <%= link_to new_sell_path, class: "flex text-sm font-bold rounded bg-success px-4 py-2 text-white items-center gap-2" do %>
       <span>Añadir venta</span>

--- a/app/views/sells/new.html.erb
+++ b/app/views/sells/new.html.erb
@@ -1,11 +1,5 @@
-<div class="flex flex-col h-full w-full">
-  <%= render 'shared/navbar' do %>
-    <h1 class="font-bold text-2xl text-sidebarTextColor">Añadir venta</h1>
+<%= turbo_frame_tag 'new_sell', class:"flex flex-col w-full" do %>
+  <%= render 'shared/modal', { title: 'Añadir nueva venta' } do %>
+    <%= render 'form', { sell: @sell, id: 'new_sell_form', btn_text: 'Crear' } %>
   <% end %>
-
-  <div class="flex flex-col overflow-y-auto p-5 gap-10 m-5 bg-white border rounded shadow">
-    <%= render 'shared/breadcumb', { path: sells_path, path_text: 'Ventas', text: 'Añadir venta' } %>
-
-    <%= render "form", { sell: @sell, btn_title: 'Guardar', cancel_path: sells_path, articles: Article.available_in_stock } %>
-  </div>
-</div>
+<% end %>

--- a/app/views/sells/show.html.erb
+++ b/app/views/sells/show.html.erb
@@ -1,6 +1,8 @@
+<%= turbo_frame_tag 'edit_sell' %>
+
 <section class="flex flex-col h-full w-full">
   <%= render 'shared/navbar' do %>
-    <h1 class="font-bold text-2xl text-sidebarTextColor">Información de la venta</h1>
+    <h1 class="font-bold text-2xl text-sidebarTextColor">Venta no. <%= @sell.id %></h1>
   <% end %>
 
   <div class="flex flex-col w-full p-5 gap-5">
@@ -8,27 +10,6 @@
       <%= render 'sell', sell: @sell %>
     </div>
 
-    <div class="flex flex-col w-full bg-white shadow rounded border p-5 gap-5">
-      <h5 class="font-bold text-lg text-sidebarTextColor">Otras ventas de este articulo</h5>
-      <div class="flex flex-col gap-2">
-        <div class="flex w-full bg-gray-100 rounded">
-          <div class="w-1/6 text-sidebarTextColor font-bold">ID</div>
-          <div class="w-3/6 text-sidebarTextColor font-bold">Fecha</div>
-          <div class="w-1/6 text-sidebarTextColor font-bold">Cantidad</div>
-          <div class="w-1/6 text-sidebarTextColor font-bold">Ganancia</div>
-        </div>
-        <div class="flex flex-col w-full gap-2">
-          <% @sell.article.sells.each do |sell| %>
-            <% next if sell.eql? @sell %>
-            <div class="flex items-center w-full border-b py-2">
-              <div class="w-1/6 text-sidebarTextColor font-semibold text-sm"><%= sell.id %></div>
-              <div class="w-3/6 text-sidebarTextColor font-semibold text-sm"><%= I18n.l(sell.date_of_sell.to_time, format: :long) %></div>
-              <div class="w-1/6 text-sidebarTextColor font-semibold text-sm"><%= sell.quantity %></div>
-              <div class="w-1/6 text-sidebarTextColor font-semibold text-sm">$ <%= number_with_delimiter(sell.total_revenue.round(2), :delimiter => ',') %> MXN</div>
-            </div>
-          <% end %>
-        </div>
-      </div>
-    </div>
+    <%= render 'article_sells/article_sells', { sell: @sell } %>
   </div>
 </section>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -67,14 +67,19 @@ en:
       sell:
         date_of_sell: La fecha de la venta
         description: La descripción
+      article_sell:
+        quantity: La cantidad
+        article_id: El articulo
 
     errors:
       models:
-        sell:
-          invalid_day: 'no coincide con los dias mostrados en la lista'
-          insufficient_articles: 'es mayor a los articulos en stock'
         article:
           content_type_invalid: 'es un formato invalido. Formatos permitidos: %{authorized_types}'
+        sell:
+          greater_than_today: es mayor a la fecha actual
+        article_sell:
+          insufficient_articles: 'es mayor que el numero de articulos en stock'
+          article_does_not_exist: 'no esta registrado en el inventario'
 
       messages:
         blank: 'no debe estar en blanco'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -58,7 +58,6 @@ en:
         name: El nombre
         description: La descripción
         price: El precio
-        in_stock: La cantidad en almacén
         categories: Las categorias
         avatar: Imagen principal
         images: Imagenes

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -65,11 +65,8 @@ en:
       category:
         name: El nombre
       sell:
-        quantity: Total de piezas a vender
-        day: El día
         date_of_sell: La fecha de la venta
-        comment: El comentario
-        article: El articulo
+        description: La descripción
 
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   resources :sells do
     post '/filter', to: 'sells#filter', on: :collection
+    resources :article_sells
   end
 
   resources :categories
@@ -10,7 +11,6 @@ Rails.application.routes.draw do
     post '/save_categories', to: 'articles#save_categories', on: :member
     post '/search_by_name', to: 'articles#search_by_name', on: :collection
     post '/filter', to: 'articles#filter', on: :collection
-    # patch '/set_categories', to: ''
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   get '/settings', to: 'pages#settings'

--- a/db/articles_seed.rb
+++ b/db/articles_seed.rb
@@ -2,12 +2,7 @@
 food_category = Category.find_by(name: 'Comida')
 
 for i in 0...5 do
-  article = Article.create(
-    name: Faker::Food.allergen,
-    price: rand(100.0...2000.0).round(2),
-    description: Faker::Food.description,
-    in_stock: rand(5..20)
-  )
+  article = Article.create(name: Faker::Food.allergen, price: rand(100.0...2000.0).round(2), description: Faker::Food.description)
 
   article.categories << food_category
 end
@@ -16,12 +11,7 @@ end
 computer_category = Category.find_by(name: 'Computadoras')
 
 for i in 0...5 do
-  article = Article.create(
-    name: Faker::Computer.stack,
-    price: rand(100.0...2000.0).round(2),
-    description: Faker::Computer.platform,
-    in_stock: rand(5..20)
-  )
+  article = Article.create(name: Faker::Computer.stack, price: rand(100.0...2000.0).round(2), description: Faker::Computer.platform)
 
   article.categories << computer_category
 end
@@ -30,12 +20,7 @@ end
 videogames_category = Category.find_by(name: 'Videojuegos')
 
 for i in 0...5 do
-  article = Article.create(
-    name: Faker::Game.title,
-    price: rand(100.0...2000.0).round(2),
-    description: Faker::Game.platform,
-    in_stock: rand(5..20)
-  )
+  article = Article.create(name: Faker::Game.title, price: rand(100.0...2000.0).round(2), description: Faker::Game.platform)
 
   article.categories << videogames_category
 end
@@ -44,12 +29,7 @@ end
 movies_category = Category.find_by(name: 'Peliculas')
 
 for i in 0...5 do
-  article = Article.create(
-    name: Faker::Movie.title,
-    price: rand(100.0...2000.0).round(2),
-    description: Faker::Movie.quote,
-    in_stock: rand(5..20)
-  )
+  article = Article.create(name: Faker::Movie.title, price: rand(100.0...2000.0).round(2), description: Faker::Movie.quote)
 
   article.categories << movies_category
 end
@@ -58,12 +38,7 @@ end
 books_category = Category.find_by(name: 'Libros y novelas')
 
 for i in 0...5 do
-  article = Article.create(
-    name: Faker::Book.title,
-    price: rand(100.0...2000.0).round(2),
-    description: Faker::Book.genre,
-    in_stock: rand(5..20)
-  )
+  article = Article.create(name: Faker::Book.title, price: rand(100.0...2000.0).round(2), description: Faker::Book.genre)
 
   article.categories << books_category
 end
@@ -72,12 +47,7 @@ end
 furniture_category = Category.find_by(name: 'Muebles')
 
 for i in 0...5 do
-  article = Article.create(
-    name: Faker::House.furniture,
-    price: rand(100.0...2000.0).round(2),
-    description: Faker::House.room,
-    in_stock: rand(5..20)
-  )
+  article = Article.create(name: Faker::House.furniture, price: rand(100.0...2000.0).round(2), description: Faker::House.room)
 
   article.categories << furniture_category
 end
@@ -86,12 +56,7 @@ end
 cars_cateogry = Category.find_by(name: 'Autos')
 
 for i in 0...5 do
-  article = Article.create(
-    name: Faker::Vehicle.make_and_model,
-    price: rand(100.0...2000.0).round(2),
-    description: Faker::Vehicle.drive_type + Faker::Vehicle.transmission + Faker::Vehicle.color,
-    in_stock: rand(5..20)
-  )
+  article = Article.create(name: Faker::Vehicle.make_and_model, price: rand(100.0...2000.0).round(2), description: Faker::Vehicle.drive_type + Faker::Vehicle.transmission + Faker::Vehicle.color)
 
   article.categories << cars_cateogry
 end
@@ -100,12 +65,7 @@ end
 music_category = Category.find_by(name: 'Musica')
 
 for i in 0...5 do
-  article = Article.create(
-    name: Faker::Music.instrument,
-    price: rand(100.0...2000.0).round(2),
-    description: Faker::Music.album,
-    in_stock: rand(5..20)
-  )
+  article = Article.create(name: Faker::Music.instrument,price: rand(100.0...2000.0).round(2),description: Faker::Music.album)
 
   article.categories << music_category
 end

--- a/db/migrate/20230914212750_remove_sells_articles_reference.rb
+++ b/db/migrate/20230914212750_remove_sells_articles_reference.rb
@@ -1,0 +1,5 @@
+class RemoveSellsArticlesReference < ActiveRecord::Migration[7.0]
+  def change
+    remove_reference :sells, :article, index: true, foreign_key: true
+  end
+end

--- a/db/migrate/20230914212938_remove_sells_count_cache_from_articles.rb
+++ b/db/migrate/20230914212938_remove_sells_count_cache_from_articles.rb
@@ -1,0 +1,5 @@
+class RemoveSellsCountCacheFromArticles < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :articles, :sells_count
+  end
+end

--- a/db/migrate/20230914214333_create_article_sells.rb
+++ b/db/migrate/20230914214333_create_article_sells.rb
@@ -1,0 +1,10 @@
+class CreateArticleSells < ActiveRecord::Migration[7.0]
+  def change
+    create_table :article_sells do |t|
+      t.references :article, null: false, foreign_key: true
+      t.references :sell, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230914214939_remove_quantity_total_revenue_and_comment_from_sells.rb
+++ b/db/migrate/20230914214939_remove_quantity_total_revenue_and_comment_from_sells.rb
@@ -1,0 +1,7 @@
+class RemoveQuantityTotalRevenueAndCommentFromSells < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :sells, :quantity
+    remove_column :sells, :comment
+    remove_column :sells, :total_revenue
+  end
+end

--- a/db/migrate/20230914215108_add_description_on_sells.rb
+++ b/db/migrate/20230914215108_add_description_on_sells.rb
@@ -1,0 +1,5 @@
+class AddDescriptionOnSells < ActiveRecord::Migration[7.0]
+  def change
+    add_column :sells, :description, :string
+  end
+end

--- a/db/migrate/20230914215315_add_quantity_revenue_to_article_sells_table.rb
+++ b/db/migrate/20230914215315_add_quantity_revenue_to_article_sells_table.rb
@@ -1,0 +1,6 @@
+class AddQuantityRevenueToArticleSellsTable < ActiveRecord::Migration[7.0]
+  def change
+    add_column :article_sells, :quantity, :integer
+    add_column :article_sells, :revenue, :decimal, default: 0.0
+  end
+end

--- a/db/migrate/20230915184107_remove_in_stock_from_articles.rb
+++ b/db/migrate/20230915184107_remove_in_stock_from_articles.rb
@@ -1,0 +1,5 @@
+class RemoveInStockFromArticles < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :articles, :in_stock
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_13_230459) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_14_215315) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,13 +52,23 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_13_230459) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "article_sells", force: :cascade do |t|
+    t.bigint "article_id", null: false
+    t.bigint "sell_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "quantity"
+    t.decimal "revenue", default: "0.0"
+    t.index ["article_id"], name: "index_article_sells_on_article_id"
+    t.index ["sell_id"], name: "index_article_sells_on_sell_id"
+  end
+
   create_table "articles", force: :cascade do |t|
     t.string "name"
     t.decimal "price"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "in_stock"
-    t.integer "sells_count", default: 0
   end
 
   create_table "articles_categories", id: false, force: :cascade do |t|
@@ -75,17 +85,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_13_230459) do
   end
 
   create_table "sells", force: :cascade do |t|
-    t.bigint "article_id", null: false
-    t.integer "quantity"
     t.date "date_of_sell"
-    t.string "comment"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.decimal "total_revenue", default: "0.0"
-    t.index ["article_id"], name: "index_sells_on_article_id"
+    t.string "description"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "sells", "articles"
+  add_foreign_key "article_sells", "articles"
+  add_foreign_key "article_sells", "sells"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_14_215315) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_15_184107) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -68,7 +68,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_14_215315) do
     t.decimal "price"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "in_stock"
   end
 
   create_table "articles_categories", id: false, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,11 +7,11 @@
 #   Character.create(name: "Luke", movie: movies.first)
 
 if Rails.env.development?
-  puts 'Seeding Categories...'
-  require_relative './categories_seed'
+  # puts 'Seeding Categories...'
+  # require_relative './categories_seed'
 
-  puts 'Seeding Articles...'
-  require_relative './articles_seed'
+  # puts 'Seeding Articles...'
+  # require_relative './articles_seed'
 
   # puts 'Seeding Sells...'
   # require_relative './sells_seed'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,6 +13,6 @@ if Rails.env.development?
   puts 'Seeding Articles...'
   require_relative './articles_seed'
 
-  puts 'Seeding Sells...'
-  require_relative './sells_seed'
+  # puts 'Seeding Sells...'
+  # require_relative './sells_seed'
 end

--- a/db/sells_seed.rb
+++ b/db/sells_seed.rb
@@ -1,20 +1,20 @@
 # Sells
 
-def time_rand from = 0.0, to = Time.now
+if Article.all.any?
+  first_article_id = Article.first.id
+  last_article_id = Article.last.id
+end
+
+def time_rand(from = 0.0, to = Time.now)
   Time.at(from + rand * (to.to_f - from.to_f))
 end
 
-for i in 1...100 do
-  id = rand(Article.first.id..Article.all.count)
-  day = rand(0...7)
+for i in 1...50 do
+  @sell = Sell.create(date_of_sell: time_rand(Time.local(2023, 8, 15)))
 
-  article = Article.find(id)
+  for i in 1...10 do
+    id = rand(first_article_id..last_article_id)
 
-  if article && article.in_stock > 0
-    Sell.create(
-      article: article,
-      quantity: rand(1..article.in_stock),
-      date_of_sell: time_rand(Time.local(2023, 8, 8))
-    )
+    @sell.article_sells.create(article_id: id, quantity: rand(1...10))
   end
 end

--- a/spec/factories/article_sells.rb
+++ b/spec/factories/article_sells.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :article_sell do
+    article { nil }
+    sell { nil }
+  end
+end

--- a/spec/factories/article_sells.rb
+++ b/spec/factories/article_sells.rb
@@ -1,6 +1,15 @@
 FactoryBot.define do
   factory :article_sell do
-    article { nil }
-    sell { nil }
+    trait :with_attributes do
+      quantity { 5 }
+    end
+
+    trait :with_sell do
+      sell { create(:sell, :with_attributes) }
+    end
+
+    trait :with_article do
+      article { create(:article, :with_attributes) }
+    end
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -6,14 +6,6 @@ FactoryBot.define do
       price { 399.66 }
     end
 
-    trait :with_stock do
-      in_stock { 15 }
-    end
-
-    trait :without_stock do
-      in_stock { 0 }
-    end
-
     trait :with_second_price do
       price { 3524.31 }
     end

--- a/spec/factories/sells.rb
+++ b/spec/factories/sells.rb
@@ -1,16 +1,8 @@
 FactoryBot.define do
   factory :sell do
     trait :with_attributes do
-      quantity { 3 }
       date_of_sell { '2023-09-09' }
-    end
-
-    trait :with_article do
-      article { build(:article, :with_attributes, :with_stock) }
-    end
-
-    trait :with_more_quantity do
-      quantity { 50 }
+      description { 'It was created yesterday' }
     end
   end
 end

--- a/spec/models/article_sell_spec.rb
+++ b/spec/models/article_sell_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ArticleSell, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/article_sell_spec.rb
+++ b/spec/models/article_sell_spec.rb
@@ -1,5 +1,61 @@
 require 'rails_helper'
 
 RSpec.describe ArticleSell, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:article_sell_default) { build(:article_sell, :with_attributes, :with_sell, :with_article) }
+  let(:invalid_article_sell) { build(:article_sell) }
+
+  describe 'instances' do
+    it 'should be a valid instance' do
+      expect(article_sell_default).to be_valid
+    end
+
+    it 'should not be a valid instance' do
+      expect(invalid_article_sell).to be_invalid
+    end
+  end
+
+  describe 'associations' do
+    it { should belong_to(:article) }
+    it { should belong_to(:sell) }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:article_id) }
+    it { should validate_presence_of(:quantity) }
+
+    it 'should return error if quantity is less than 0' do
+      article_sell_default.quantity = -1
+
+      expect(article_sell_default).to be_invalid
+    end
+  end
+
+  describe 'custom validations' do
+    it 'should return error if the article is not present in the database' do
+      article_sell_default.article_id = 999
+
+      expect(article_sell_default).to be_invalid
+    end
+  end
+
+  describe 'callbacks' do
+    it 'should set the revenue automatically after adding the article' do
+      expect(article_sell_default.revenue).to be_eql(0.0)
+
+      article_sell_default.save
+
+      expect(article_sell_default.revenue).to be_eql(1_998.3)
+    end
+
+    it 'should set the revenue automatically after updating the quantity with the article' do
+      article_sell_default.save
+
+      expect(article_sell_default.revenue).to be_eql(1_998.3)
+
+      article_sell_default.update(quantity: 2)
+
+      expect(article_sell_default.revenue).to_not be_eql(1_998.3)
+      expect(article_sell_default.revenue.to_i).to be_eql(799.32.to_i)
+    end
+  end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Article, type: :model do
-  let(:article_one) { build(:article, :with_attributes, :with_stock) }
-  let(:article_two) { build(:article, :with_attributes, :without_stock, name: 'Iphone 14', price: 799.99) }
-  let(:article_three) { build(:article, :with_attributes, :with_stock, name: 'Iphone 15', price: 599.99) }
+  let(:article_one) { build(:article, :with_attributes) }
+  let(:article_two) { build(:article, :with_attributes, name: 'Iphone 14', price: 799.99) }
+  let(:article_three) { build(:article, :with_attributes, name: 'Iphone 15', price: 599.99) }
   let(:category_one) { build(:category, :with_attributes) }
   let(:invalid_article) { build(:article) }
 
@@ -25,6 +25,12 @@ RSpec.describe Article, type: :model do
       @articles = Article.all
     end
 
+    it 'should return the articles with a similar name' do
+      expect(@articles.count).to be_eql(3)
+      expect(Article.search_with_name('Iph').count).to be_eql(2)
+      expect(Article.search_with_name('Pl').count).to be_eql(1)
+    end
+
     it 'should return the articles with a min price specified' do
       expect(@articles.count).to be_eql(3)
       expect(Article.with_min_price(@articles, 500.00).count).to be_eql(2)
@@ -40,7 +46,6 @@ RSpec.describe Article, type: :model do
 
   describe 'validations' do
     it { should validate_presence_of(:name) }
-    it { should validate_presence_of(:description) }
     it { should validate_presence_of(:price) }
     it { should validate_uniqueness_of(:name) }
   end
@@ -56,7 +61,8 @@ RSpec.describe Article, type: :model do
   end
 
   describe 'associations' do
-    it { should have_many(:sells) }
+    it { should have_many(:article_sells) }
+    it { should have_many(:sells).through(:article_sells) }
     it { should have_and_belong_to_many(:categories) }
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -25,11 +25,6 @@ RSpec.describe Article, type: :model do
       @articles = Article.all
     end
 
-    it 'should return the articles with more than 0 in stock' do
-      expect(@articles.count).to be_eql(3)
-      expect(Article.available_in_stock.count).to be_eql(2)
-    end
-
     it 'should return the articles with a min price specified' do
       expect(@articles.count).to be_eql(3)
       expect(Article.with_min_price(@articles, 500.00).count).to be_eql(2)
@@ -47,7 +42,6 @@ RSpec.describe Article, type: :model do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:description) }
     it { should validate_presence_of(:price) }
-    it { should validate_presence_of(:in_stock) }
     it { should validate_uniqueness_of(:name) }
   end
 
@@ -64,12 +58,6 @@ RSpec.describe Article, type: :model do
   describe 'associations' do
     it { should have_many(:sells) }
     it { should have_and_belong_to_many(:categories) }
-  end
-
-  describe 'public methods' do
-    it 'should return the name with the in stock attributes' do
-      expect(article_one.name_with_in_stock).to be_eql('Play Station 5 (15 pz disp)')
-    end
   end
 
   describe 'set categories' do

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Category, type: :model do
   let(:category_one) { build(:category, :with_attributes) }
-  let(:article_one) { build(:article, :with_attributes, :with_stock) }
+  let(:article_one) { build(:article, :with_attributes) }
   let(:invalid_category) { build(:category) }
 
   describe 'instances' do

--- a/spec/models/sell_spec.rb
+++ b/spec/models/sell_spec.rb
@@ -2,17 +2,16 @@ require 'rails_helper'
 
 RSpec.describe Sell, type: :model do
   let(:sell_default) { build(:sell, :with_attributes) }
-  let(:sell_one) { build(:sell, :with_attributes, :with_article) }
-  let(:sell_two) { build(:sell, :with_attributes, :with_article, :with_more_quantity) }
-  let(:sell_three) { build(:sell, :with_attributes, article: article_one) }
-  let(:article_one) { build(:article, :with_attributes, :with_stock) }
-  let(:article_two) { build(:article, :with_attributes, :with_stock, :with_second_price) }
-  let(:article_three) { build(:article, :with_attributes, :with_stock, :with_third_price) }
-  let(:invalid_sell) { build(:sell, :with_attributes) }
+  let(:invalid_sell) { build(:sell) }
+  let(:article_one) { build(:article, :with_attributes) }
+  let(:sell_one) { build(:sell, :with_attributes, date_of_sell: '2023-09-09') }
+  let(:sell_two) { build(:sell, :with_attributes, date_of_sell: '2023-08-08') }
+  let(:article_sell_one) { build(:article_sell, :with_attributes) }
+  let(:article_sell_two) { build(:article_sell, :with_attributes, quantity: 10) }
 
   describe 'instances' do
     it 'should be a valid instance' do
-      expect(sell_one).to be_valid
+      expect(sell_default).to be_valid
     end
 
     it 'should be an invalid instance' do
@@ -23,13 +22,8 @@ RSpec.describe Sell, type: :model do
   describe 'scopes' do
     before do
       article_one.save
-      sell_one.article_id = article_one.id
-      sell_two.article_id = article_one.id
-      sell_two.date_of_sell = '2023-07-07'.to_date
-
       sell_one.save
       sell_two.save
-
       @sells = Sell.all
     end
 
@@ -47,83 +41,56 @@ RSpec.describe Sell, type: :model do
   end
 
   describe 'validations' do
-    it { should validate_presence_of(:quantity) }
     it { should validate_presence_of(:date_of_sell) }
-    it { should validate_presence_of(:article) }
+  end
+
+  describe 'custom validations' do
+    it 'should return error if date of sell is greater than today' do
+      sell_one.date_of_sell = Date.today + 2.day
+
+      expect(sell_one).to be_invalid
+    end
+  end
+
+  describe 'associations' do
+    it { should have_many(:article_sells) }
+    it { should have_many(:articles).through(:article_sells) }
   end
 
   describe 'callbacks' do
-    describe 'before create, the total revenue' do
-      it 'should set automatically with the article one' do
-        article_one.save
-        sell_default.article_id = article_one.id
+    it 'should delete all the articles_sells associations if the sell is deleted' do
+      article_one.save
+      sell_one.save
 
-        expect(sell_default).to be_valid
-        sell_default.save
-        expect(sell_default.total_revenue).to be_present
-        expect(sell_default.total_revenue).to be_eql(1198.98)
-      end
+      sell_one.article_sells.create(article: article_one, quantity: 5)
+      sell_one.article_sells.create(article: article_one, quantity: 15)
 
-      it 'should set automatically with the article two' do
-        article_two.save
-        sell_default.article_id = article_two.id
+      expect(ArticleSell.count).to be_eql(2)
 
-        expect(sell_default).to be_valid
-        sell_default.save
-        expect(sell_default.total_revenue).to be_present
-        expect(sell_default.total_revenue).to be_eql(10_572.93)
-      end
+      sell_one.destroy
 
-      it 'should set automatically with the article three' do
-        article_three.save
-        sell_default.article_id = article_three.id
-
-        expect(sell_default).to be_valid
-        sell_default.save
-        expect(sell_default.total_revenue).to be_present
-        expect(sell_default.total_revenue).to be_eql(3_820.98)
-      end
+      expect(ArticleSell.count).to be_eql(0)
     end
+  end
 
-    describe 'before update, the total revenue' do
-      it 'should updated automatically the sell with article one' do
-        article_one.save
-        sell_default.article_id = article_one.id
-        sell_default.save
+  describe 'class methods' do
+    it 'should return the latest sells with the total revenue by day' do
+      article_one.save
+      sell_one.date_of_sell = Date.today
+      sell_one.save
 
-        expect(sell_default.total_revenue).to be_eql(1198.98)
+      article_sell_one.sell = sell_one
+      article_sell_one.article = article_one
+      article_sell_one.save
 
-        sell_default.update(quantity: 8)
+      article_sell_two.sell = sell_one
+      article_sell_two.article = article_one
+      article_sell_two.save
 
-        expect(sell_default.total_revenue).to_not be_eql(1198.98)
-        expect(sell_default.total_revenue).to be_eql(3_197.28)
-      end
 
-      it 'should updated automatically the sell with article two' do
-        article_two.save
-        sell_default.article_id = article_two.id
-        sell_default.save
-
-        expect(sell_default.total_revenue).to be_eql(10_572.93)
-
-        sell_default.update(quantity: 8)
-
-        expect(sell_default.total_revenue).to_not be_eql(10_572.93)
-        expect(sell_default.total_revenue).to be_eql(28_194.48)
-      end
-
-      it 'should updated automatically the sell with article three' do
-        article_three.save
-        sell_default.article_id = article_three.id
-        sell_default.save
-
-        expect(sell_default.total_revenue).to_not be_eql(1198.98)
-
-        sell_default.update(quantity: 8)
-
-        expect(sell_default.total_revenue).to_not be_eql(3_820.98)
-        expect(sell_default.total_revenue).to be_eql(10_189.28)
-      end
+      expect(Sell.revenue_by_day.length).to be_eql(30)
+      expect(Sell.revenue_by_day[0].length).to be_eql(2)
+      expect(Sell.revenue_by_day[0].last).to be_eql(5_994.9)
     end
   end
 end

--- a/spec/models/sell_spec.rb
+++ b/spec/models/sell_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe Sell, type: :model do
 
   describe 'scopes' do
     before do
-      article_one.in_stock = 200
       article_one.save
       sell_one.article_id = article_one.id
       sell_two.article_id = article_one.id
@@ -53,22 +52,7 @@ RSpec.describe Sell, type: :model do
     it { should validate_presence_of(:article) }
   end
 
-  describe 'custom validations' do
-    it 'should validate the quantity against the article.in_stock attribute' do
-      expect(sell_two).to_not be_valid
-      expect(sell_two.errors).to be_present
-      expect(sell_two.errors.first.message).to be_eql('es mayor a los articulos en stock')
-    end
-  end
-
   describe 'callbacks' do
-    it 'should decrease the article.in_stock value depending on the quantity of sells' do
-      article_one.save
-      expect(article_one.in_stock).to be_eql(15)
-      sell_three.save
-      expect(article_one.in_stock).to be_eql(12)
-    end
-
     describe 'before create, the total revenue' do
       it 'should set automatically with the article one' do
         article_one.save


### PR DESCRIPTION
# Update the Association between Sells and Articles, as well as the current default configuration when users create sales and add articles

## Description

This PR updates the association between sales and articles. The previous association didn't allow to addition of more articles to a single sale. A sale can have multiple articles. This is necessary to generate the correct PDFs and measure the sales easily.